### PR TITLE
fix: package typing location

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Casper UI Kit",
   "main": "lib/index.js",
   "module": "lib/index.esm.js",
-  "types": "build/index.d.ts",
+  "types": "lib/index.d.ts",
   "scripts": {
     "audit": "better-npm-audit audit",
     "prepublish": "npm run build",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "./src",
-    "outDir": "./build",
+    "outDir": "./lib",
     "target": "ESNext",
     "lib": [
       "dom",
@@ -23,7 +23,7 @@
     "jsx": "react-jsx",
     "baseUrl": ".",
     "declaration": true,
-    "declarationDir": "./build",
+    "declarationDir": "./lib",
     "sourceMap": true,
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,


### PR DESCRIPTION
### 🔥 Summary
TypeScript Types were in `/build` and the `.npmignore` ignores that directory

### 😤 Problem / Goals
- NPM package is missing types

### 🤓 Solution
- Move typing output from build script into lib
- Update package.json types path
