### PR TITLE
Refactor/UI kit issue#92

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -22,7 +22,7 @@ export const Button: React.FC<ButtonProps> = ({
   type,
   className,
   isDisabled = false,
-  ...rest
+  ...baseButtonProps
 }) => {
   return (
     <StyledButton
@@ -32,7 +32,7 @@ export const Button: React.FC<ButtonProps> = ({
       color={color}
       onClick={onClick}
       disabled={isDisabled}
-      {...rest}>
+      {...baseButtonProps}>
       {children}
     </StyledButton>
   );

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -11,7 +11,7 @@ export interface ButtonProps extends InputHTMLAttributes<HTMLButtonElement> {
   readonly color?: string;
   readonly type: ButtonType;
   readonly className?: string;
-  readonly isDisabled?: boolean;
+  readonly disabled?: boolean;
 }
 
 export const Button: React.FC<ButtonProps> = ({
@@ -21,7 +21,7 @@ export const Button: React.FC<ButtonProps> = ({
   color = 'white',
   type,
   className,
-  isDisabled = false,
+  disabled = false,
   ...baseButtonProps
 }) => {
   return (
@@ -31,7 +31,7 @@ export const Button: React.FC<ButtonProps> = ({
       bgColor={bgColor}
       color={color}
       onClick={onClick}
-      disabled={isDisabled}
+      disabled={disabled}
       {...baseButtonProps}>
       {children}
     </StyledButton>

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,10 +1,10 @@
-import React from 'react';
+import React, { InputHTMLAttributes } from 'react';
 import styled from '@emotion/styled';
 import { pxToRem } from '../../utils';
 
 export type ButtonType = 'submit' | 'reset' | 'button';
 
-export interface ButtonProps {
+export interface ButtonProps extends InputHTMLAttributes<HTMLButtonElement> {
   readonly children: React.ReactNode;
   readonly onClick?: () => void;
   readonly bgColor?: string;
@@ -22,6 +22,7 @@ export const Button: React.FC<ButtonProps> = ({
   type,
   className,
   isDisabled = false,
+  ...rest
 }) => {
   return (
     <StyledButton
@@ -30,7 +31,8 @@ export const Button: React.FC<ButtonProps> = ({
       bgColor={bgColor}
       color={color}
       onClick={onClick}
-      disabled={isDisabled}>
+      disabled={isDisabled}
+      {...rest}>
       {children}
     </StyledButton>
   );

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -1,11 +1,11 @@
 import styled from '@emotion/styled';
-import React, { forwardRef, useState } from 'react';
+import React, { InputHTMLAttributes, forwardRef, useState } from 'react';
 import { pxToRem } from '../../utils';
 import CheckboxSvg from '../../assets/svg/icons/checkbox.svg';
 
 export type LabelPositions = 'top' | 'right' | 'bottom' | 'left';
 
-export interface CheckboxProps {
+export interface CheckboxProps extends InputHTMLAttributes<HTMLInputElement> {
   readonly checked?: boolean;
   readonly boxColor?: string;
   readonly checkmarkColor?: string;
@@ -21,15 +21,17 @@ export interface CheckboxProps {
   readonly value?: string | number;
   readonly onChange?: React.ChangeEventHandler<HTMLInputElement>;
   readonly ref?: React.ForwardedRef<HTMLInputElement>;
+  readonly id?: string;
 }
 
 export const Checkbox: React.FC<CheckboxProps> = forwardRef(
   (
     {
-      boxColor = '#02c1b0',
-      checkmarkColor = '#02c1b0',
+      id = 'checkbox',
       label = 'Checkbox Label',
       labelPosition = 'left',
+      boxColor = '#02c1b0',
+      checkmarkColor = '#02c1b0',
       gapSize = 10,
       width = 30,
       borderWidth = 2,
@@ -40,6 +42,7 @@ export const Checkbox: React.FC<CheckboxProps> = forwardRef(
       value,
       name,
       required,
+      ...baseCheckboxProps
     },
     ref,
   ) => {
@@ -47,11 +50,12 @@ export const Checkbox: React.FC<CheckboxProps> = forwardRef(
 
     return (
       <LabelCheckboxContainer labelPosition={labelPosition} gapSize={gapSize}>
-        <label>{label}</label>
+        <label htmlFor={id}>{label}</label>
         <CheckboxContainer
           onClick={() => setIsChecked(prev => !prev)}
           width={width}>
           <StyledCheckbox
+            id={id}
             ref={ref}
             boxColor={boxColor}
             width={width}
@@ -63,6 +67,7 @@ export const Checkbox: React.FC<CheckboxProps> = forwardRef(
             name={name}
             checked={checked}
             required={required}
+            {...baseCheckboxProps}
           />
           {isChecked && (
             <CheckboxSvgWrapper width={width} checkmarkSize={checkmarkSize}>

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -1,11 +1,11 @@
 import styled from '@emotion/styled';
-import React, { useState } from 'react';
+import React, { InputHTMLAttributes } from 'react';
 import { pxToRem } from '../../utils';
 import CheckboxSvg from '../../assets/svg/icons/checkbox.svg';
 
 export type LabelPositions = 'top' | 'right' | 'bottom' | 'left';
 
-export interface CheckboxProps {
+export interface CheckboxProps extends InputHTMLAttributes<HTMLInputElement> {
   readonly checked?: boolean;
   readonly boxColor?: string;
   readonly checkmarkColor?: string;
@@ -37,15 +37,12 @@ export const Checkbox: React.FC<CheckboxProps> = ({
   value,
   name,
   required,
+  ...rest
 }) => {
-  const [isChecked, setIsChecked] = useState(checked);
-
   return (
     <LabelCheckboxContainer labelPosition={labelPosition} gapSize={gapSize}>
       <label>{label}</label>
-      <CheckboxContainer
-        onClick={() => setIsChecked(prev => !prev)}
-        width={width}>
+      <CheckboxContainer width={width}>
         <StyledCheckbox
           boxColor={boxColor}
           width={width}
@@ -57,8 +54,9 @@ export const Checkbox: React.FC<CheckboxProps> = ({
           name={name}
           checked={checked}
           required={required}
+          {...rest}
         />
-        {isChecked && (
+        {checked && (
           <CheckboxSvgWrapper width={width} checkmarkSize={checkmarkSize}>
             <StyledCheckboxSvg
               checkmarkColor={checkmarkColor}

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -1,11 +1,11 @@
 import styled from '@emotion/styled';
-import React, { InputHTMLAttributes, forwardRef, useState } from 'react';
+import React, { forwardRef, useState } from 'react';
 import { pxToRem } from '../../utils';
 import CheckboxSvg from '../../assets/svg/icons/checkbox.svg';
 
 export type LabelPositions = 'top' | 'right' | 'bottom' | 'left';
 
-export interface CheckboxProps extends InputHTMLAttributes<HTMLInputElement> {
+export interface CheckboxProps {
   readonly checked?: boolean;
   readonly boxColor?: string;
   readonly checkmarkColor?: string;
@@ -23,61 +23,63 @@ export interface CheckboxProps extends InputHTMLAttributes<HTMLInputElement> {
   readonly ref?: React.ForwardedRef<HTMLInputElement>;
 }
 
-export const Checkbox: React.FC<CheckboxProps> = forwardRef(function Checkbox(
-  {
-    boxColor = '#02c1b0',
-    checkmarkColor = '#02c1b0',
-    label = 'Checkbox Label',
-    labelPosition = 'left',
-    gapSize = 10,
-    width = 30,
-    borderWidth = 2,
-    checkmarkSize = 65,
-    checked,
-    disabled,
-    onChange,
-    value,
-    name,
-    required,
-    ...rest
-  },
-  ref,
-) {
-  const [isChecked, setIsChecked] = useState(checked);
+export const Checkbox: React.FC<CheckboxProps> = forwardRef(
+  (
+    {
+      boxColor = '#02c1b0',
+      checkmarkColor = '#02c1b0',
+      label = 'Checkbox Label',
+      labelPosition = 'left',
+      gapSize = 10,
+      width = 30,
+      borderWidth = 2,
+      checkmarkSize = 65,
+      checked,
+      disabled,
+      onChange,
+      value,
+      name,
+      required,
+    },
+    ref,
+  ) => {
+    const [isChecked, setIsChecked] = useState(checked);
 
-  return (
-    <LabelCheckboxContainer labelPosition={labelPosition} gapSize={gapSize}>
-      <label>{label}</label>
-      <CheckboxContainer
-        onClick={() => setIsChecked(prev => !prev)}
-        width={width}>
-        <StyledCheckbox
-          ref={ref}
-          boxColor={boxColor}
-          width={width}
-          borderWidth={borderWidth}
-          type="checkbox"
-          onChange={onChange}
-          disabled={disabled}
-          value={value}
-          name={name}
-          checked={checked}
-          required={required}
-          {...rest}
-        />
-        {isChecked && (
-          <CheckboxSvgWrapper width={width} checkmarkSize={checkmarkSize}>
-            <StyledCheckboxSvg
-              checkmarkColor={checkmarkColor}
-              disabled={disabled}
-              required={required}
-            />
-          </CheckboxSvgWrapper>
-        )}
-      </CheckboxContainer>
-    </LabelCheckboxContainer>
-  );
-});
+    return (
+      <LabelCheckboxContainer labelPosition={labelPosition} gapSize={gapSize}>
+        <label>{label}</label>
+        <CheckboxContainer
+          onClick={() => setIsChecked(prev => !prev)}
+          width={width}>
+          <StyledCheckbox
+            ref={ref}
+            boxColor={boxColor}
+            width={width}
+            borderWidth={borderWidth}
+            type="checkbox"
+            onChange={onChange}
+            disabled={disabled}
+            value={value}
+            name={name}
+            checked={checked}
+            required={required}
+          />
+          {isChecked && (
+            <CheckboxSvgWrapper width={width} checkmarkSize={checkmarkSize}>
+              <StyledCheckboxSvg
+                checkmarkColor={checkmarkColor}
+                disabled={disabled}
+                required={required}
+              />
+            </CheckboxSvgWrapper>
+          )}
+        </CheckboxContainer>
+      </LabelCheckboxContainer>
+    );
+  },
+);
+
+Checkbox.displayName = 'Checkbox';
 
 const LabelCheckboxContainer = styled.div<{
   labelPosition: LabelPositions;

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled';
-import React, { InputHTMLAttributes } from 'react';
+import React, { InputHTMLAttributes, forwardRef, useState } from 'react';
 import { pxToRem } from '../../utils';
 import CheckboxSvg from '../../assets/svg/icons/checkbox.svg';
 
@@ -20,30 +20,39 @@ export interface CheckboxProps extends InputHTMLAttributes<HTMLInputElement> {
   readonly name?: string;
   readonly value?: string | number;
   readonly onChange?: React.ChangeEventHandler<HTMLInputElement>;
+  readonly ref?: React.ForwardedRef<HTMLInputElement>;
 }
 
-export const Checkbox: React.FC<CheckboxProps> = ({
-  boxColor = '#02c1b0',
-  checkmarkColor = '#02c1b0',
-  label = 'Checkbox Label',
-  labelPosition = 'left',
-  gapSize = 10,
-  width = 30,
-  borderWidth = 2,
-  checkmarkSize = 65,
-  checked,
-  disabled,
-  onChange,
-  value,
-  name,
-  required,
-  ...rest
-}) => {
+export const Checkbox: React.FC<CheckboxProps> = forwardRef(function Checkbox(
+  {
+    boxColor = '#02c1b0',
+    checkmarkColor = '#02c1b0',
+    label = 'Checkbox Label',
+    labelPosition = 'left',
+    gapSize = 10,
+    width = 30,
+    borderWidth = 2,
+    checkmarkSize = 65,
+    checked,
+    disabled,
+    onChange,
+    value,
+    name,
+    required,
+    ...rest
+  },
+  ref,
+) {
+  const [isChecked, setIsChecked] = useState(checked);
+
   return (
     <LabelCheckboxContainer labelPosition={labelPosition} gapSize={gapSize}>
       <label>{label}</label>
-      <CheckboxContainer width={width}>
+      <CheckboxContainer
+        onClick={() => setIsChecked(prev => !prev)}
+        width={width}>
         <StyledCheckbox
+          ref={ref}
           boxColor={boxColor}
           width={width}
           borderWidth={borderWidth}
@@ -56,7 +65,7 @@ export const Checkbox: React.FC<CheckboxProps> = ({
           required={required}
           {...rest}
         />
-        {checked && (
+        {isChecked && (
           <CheckboxSvgWrapper width={width} checkmarkSize={checkmarkSize}>
             <StyledCheckboxSvg
               checkmarkColor={checkmarkColor}
@@ -68,7 +77,7 @@ export const Checkbox: React.FC<CheckboxProps> = ({
       </CheckboxContainer>
     </LabelCheckboxContainer>
   );
-};
+});
 
 const LabelCheckboxContainer = styled.div<{
   labelPosition: LabelPositions;

--- a/src/components/Inputs/EmailInput.tsx
+++ b/src/components/Inputs/EmailInput.tsx
@@ -1,10 +1,10 @@
 import styled from '@emotion/styled';
-import React from 'react';
+import React, { InputHTMLAttributes } from 'react';
 import { pxToRem } from '../../utils';
 
 export type EmailLabelPositions = 'top' | 'right' | 'bottom' | 'left';
 
-export interface EmailInputProps {
+export interface EmailInputProps extends InputHTMLAttributes<HTMLInputElement> {
   readonly label?: string;
   readonly labelPosition?: EmailLabelPositions;
   readonly gapSize?: number;
@@ -48,6 +48,7 @@ export const EmailInput: React.FC<EmailInputProps> = ({
   onChange,
   required,
   disabled,
+  ...rest
 }) => (
   <LabelPasswordInputContainer labelPosition={labelPosition} gapSize={gapSize}>
     <label>{label}</label>
@@ -71,6 +72,7 @@ export const EmailInput: React.FC<EmailInputProps> = ({
       required={required}
       disabled={disabled}
       data-testid="email-input"
+      {...rest}
     />
   </LabelPasswordInputContainer>
 );

--- a/src/components/Inputs/EmailInput.tsx
+++ b/src/components/Inputs/EmailInput.tsx
@@ -1,10 +1,10 @@
 import styled from '@emotion/styled';
-import React, { InputHTMLAttributes, forwardRef } from 'react';
+import React, { forwardRef } from 'react';
 import { pxToRem } from '../../utils';
 
 export type EmailLabelPositions = 'top' | 'right' | 'bottom' | 'left';
 
-export interface EmailInputProps extends InputHTMLAttributes<HTMLInputElement> {
+export interface EmailInputProps {
   readonly label?: string;
   readonly labelPosition?: EmailLabelPositions;
   readonly gapSize?: number;
@@ -29,7 +29,7 @@ export interface EmailInputProps extends InputHTMLAttributes<HTMLInputElement> {
 }
 
 export const EmailInput: React.FC<EmailInputProps> = forwardRef(
-  function EmailInput(
+  (
     {
       label = 'email label',
       labelPosition = 'left',
@@ -51,42 +51,40 @@ export const EmailInput: React.FC<EmailInputProps> = forwardRef(
       onChange,
       required,
       disabled,
-      ...rest
     },
     ref,
-  ) {
-    return (
-      <LabelPasswordInputContainer
-        labelPosition={labelPosition}
-        gapSize={gapSize}>
-        <label>{label}</label>
-        <StyledPasswordInput
-          ref={ref}
-          fontSize={fontSize}
-          fontColor={fontColor}
-          boxShadowColor={boxShadowColor}
-          borderColor={borderColor}
-          focusBorderColor={focusBorderColor}
-          focusBorderWidth={focusBorderWidth}
-          width={width}
-          height={height}
-          placeholder={placeholder}
-          placeholderColor={placeholderColor}
-          type="email"
-          minLength={minEmailLength}
-          maxLength={maxEmailLength}
-          multiple={multiple}
-          pattern={pattern}
-          onChange={onChange}
-          required={required}
-          disabled={disabled}
-          data-testid="email-input"
-          {...rest}
-        />
-      </LabelPasswordInputContainer>
-    );
-  },
+  ) => (
+    <LabelPasswordInputContainer
+      labelPosition={labelPosition}
+      gapSize={gapSize}>
+      <label>{label}</label>
+      <StyledPasswordInput
+        ref={ref}
+        fontSize={fontSize}
+        fontColor={fontColor}
+        boxShadowColor={boxShadowColor}
+        borderColor={borderColor}
+        focusBorderColor={focusBorderColor}
+        focusBorderWidth={focusBorderWidth}
+        width={width}
+        height={height}
+        placeholder={placeholder}
+        placeholderColor={placeholderColor}
+        type="email"
+        minLength={minEmailLength}
+        maxLength={maxEmailLength}
+        multiple={multiple}
+        pattern={pattern}
+        onChange={onChange}
+        required={required}
+        disabled={disabled}
+        data-testid="email-input"
+      />
+    </LabelPasswordInputContainer>
+  ),
 );
+
+EmailInput.displayName = 'EmailInput';
 
 const LabelPasswordInputContainer = styled.div<{
   labelPosition: EmailLabelPositions;

--- a/src/components/Inputs/EmailInput.tsx
+++ b/src/components/Inputs/EmailInput.tsx
@@ -1,10 +1,10 @@
 import styled from '@emotion/styled';
-import React, { forwardRef } from 'react';
+import React, { InputHTMLAttributes, forwardRef } from 'react';
 import { pxToRem } from '../../utils';
 
 export type EmailLabelPositions = 'top' | 'right' | 'bottom' | 'left';
 
-export interface EmailInputProps {
+export interface EmailInputProps extends InputHTMLAttributes<HTMLInputElement> {
   readonly label?: string;
   readonly labelPosition?: EmailLabelPositions;
   readonly gapSize?: number;
@@ -26,11 +26,13 @@ export interface EmailInputProps {
   readonly required?: boolean;
   readonly onChange?: React.ChangeEventHandler<HTMLInputElement>;
   readonly ref?: React.ForwardedRef<HTMLInputElement>;
+  readonly id?: string;
 }
 
 export const EmailInput: React.FC<EmailInputProps> = forwardRef(
   (
     {
+      id = 'emailInput',
       label = 'email label',
       labelPosition = 'left',
       gapSize,
@@ -51,14 +53,16 @@ export const EmailInput: React.FC<EmailInputProps> = forwardRef(
       onChange,
       required,
       disabled,
+      ...baseInputProps
     },
     ref,
   ) => (
     <LabelPasswordInputContainer
       labelPosition={labelPosition}
       gapSize={gapSize}>
-      <label>{label}</label>
+      <label htmlFor={id}>{label}</label>
       <StyledPasswordInput
+        id={id}
         ref={ref}
         fontSize={fontSize}
         fontColor={fontColor}
@@ -78,6 +82,7 @@ export const EmailInput: React.FC<EmailInputProps> = forwardRef(
         onChange={onChange}
         required={required}
         disabled={disabled}
+        {...baseInputProps}
         data-testid="email-input"
       />
     </LabelPasswordInputContainer>

--- a/src/components/Inputs/EmailInput.tsx
+++ b/src/components/Inputs/EmailInput.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled';
-import React, { InputHTMLAttributes } from 'react';
+import React, { InputHTMLAttributes, forwardRef } from 'react';
 import { pxToRem } from '../../utils';
 
 export type EmailLabelPositions = 'top' | 'right' | 'bottom' | 'left';
@@ -25,56 +25,67 @@ export interface EmailInputProps extends InputHTMLAttributes<HTMLInputElement> {
   readonly disabled?: boolean;
   readonly required?: boolean;
   readonly onChange?: React.ChangeEventHandler<HTMLInputElement>;
+  readonly ref?: React.ForwardedRef<HTMLInputElement>;
 }
 
-export const EmailInput: React.FC<EmailInputProps> = ({
-  label = 'email label',
-  labelPosition = 'left',
-  gapSize,
-  fontSize,
-  fontColor,
-  placeholder = 'Enter email address',
-  placeholderColor,
-  boxShadowColor,
-  borderColor,
-  focusBorderColor,
-  focusBorderWidth,
-  width,
-  height,
-  minEmailLength = 1,
-  maxEmailLength = 254,
-  multiple,
-  pattern,
-  onChange,
-  required,
-  disabled,
-  ...rest
-}) => (
-  <LabelPasswordInputContainer labelPosition={labelPosition} gapSize={gapSize}>
-    <label>{label}</label>
-    <StyledPasswordInput
-      fontSize={fontSize}
-      fontColor={fontColor}
-      boxShadowColor={boxShadowColor}
-      borderColor={borderColor}
-      focusBorderColor={focusBorderColor}
-      focusBorderWidth={focusBorderWidth}
-      width={width}
-      height={height}
-      placeholder={placeholder}
-      placeholderColor={placeholderColor}
-      type="email"
-      minLength={minEmailLength}
-      maxLength={maxEmailLength}
-      multiple={multiple}
-      pattern={pattern}
-      onChange={onChange}
-      required={required}
-      disabled={disabled}
-      data-testid="email-input"
-      {...rest}
-    />
-  </LabelPasswordInputContainer>
+export const EmailInput: React.FC<EmailInputProps> = forwardRef(
+  function EmailInput(
+    {
+      label = 'email label',
+      labelPosition = 'left',
+      gapSize,
+      fontSize,
+      fontColor,
+      placeholder = 'Enter email address',
+      placeholderColor,
+      boxShadowColor,
+      borderColor,
+      focusBorderColor,
+      focusBorderWidth,
+      width,
+      height,
+      minEmailLength = 1,
+      maxEmailLength = 254,
+      multiple,
+      pattern,
+      onChange,
+      required,
+      disabled,
+      ...rest
+    },
+    ref,
+  ) {
+    return (
+      <LabelPasswordInputContainer
+        labelPosition={labelPosition}
+        gapSize={gapSize}>
+        <label>{label}</label>
+        <StyledPasswordInput
+          ref={ref}
+          fontSize={fontSize}
+          fontColor={fontColor}
+          boxShadowColor={boxShadowColor}
+          borderColor={borderColor}
+          focusBorderColor={focusBorderColor}
+          focusBorderWidth={focusBorderWidth}
+          width={width}
+          height={height}
+          placeholder={placeholder}
+          placeholderColor={placeholderColor}
+          type="email"
+          minLength={minEmailLength}
+          maxLength={maxEmailLength}
+          multiple={multiple}
+          pattern={pattern}
+          onChange={onChange}
+          required={required}
+          disabled={disabled}
+          data-testid="email-input"
+          {...rest}
+        />
+      </LabelPasswordInputContainer>
+    );
+  },
 );
 
 const LabelPasswordInputContainer = styled.div<{

--- a/src/components/Inputs/GenericInput.tsx
+++ b/src/components/Inputs/GenericInput.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled';
-import React, { useState } from 'react';
+import React, { InputHTMLAttributes, useState } from 'react';
 import { pxToRem } from '../../utils';
 import ViewPasswordIcon from '../../assets/svg/icons/view-password-icon.svg';
 import HidePasswordIcon from '../../assets/svg/icons/hide-password-icon.svg';
@@ -7,7 +7,8 @@ import HidePasswordIcon from '../../assets/svg/icons/hide-password-icon.svg';
 export type GenericLabelPositions = 'top' | 'right' | 'bottom' | 'left';
 export type GenericTypes = 'text' | 'email' | 'password';
 
-export interface GenericInputProps {
+export interface GenericInputProps
+  extends InputHTMLAttributes<HTMLInputElement> {
   readonly inputType: GenericTypes;
   readonly label?: string;
   readonly labelPosition?: GenericLabelPositions;
@@ -57,6 +58,7 @@ export const GenericInput: React.FC<GenericInputProps> = ({
   onChange,
   required,
   disabled,
+  ...rest
 }) => {
   const [passwordIsVisible, setPasswordIsVisible] =
     useState<boolean>(passwordToggle);
@@ -86,6 +88,7 @@ export const GenericInput: React.FC<GenericInputProps> = ({
           required={required}
           disabled={disabled}
           data-testid="generic-input"
+          {...rest}
         />
         {passwordToggle && (
           <ViewPasswordButton

--- a/src/components/Inputs/GenericInput.tsx
+++ b/src/components/Inputs/GenericInput.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled';
-import React, { forwardRef, useState } from 'react';
+import React, { InputHTMLAttributes, forwardRef, useState } from 'react';
 import { pxToRem } from '../../utils';
 import ViewPasswordIcon from '../../assets/svg/icons/view-password-icon.svg';
 import HidePasswordIcon from '../../assets/svg/icons/hide-password-icon.svg';
@@ -7,7 +7,8 @@ import HidePasswordIcon from '../../assets/svg/icons/hide-password-icon.svg';
 export type GenericLabelPositions = 'top' | 'right' | 'bottom' | 'left';
 export type GenericTypes = 'text' | 'email' | 'password' | 'radio';
 
-export interface GenericInputProps {
+export interface GenericInputProps
+  extends InputHTMLAttributes<HTMLInputElement> {
   readonly inputType: GenericTypes;
   readonly label?: string;
   readonly labelPosition?: GenericLabelPositions;
@@ -32,12 +33,14 @@ export interface GenericInputProps {
   readonly required?: boolean;
   readonly onChange?: React.ChangeEventHandler<HTMLInputElement>;
   readonly ref?: React.ForwardedRef<HTMLInputElement>;
+  readonly id?: string;
 }
 
 export const GenericInput: React.FC<GenericInputProps> = forwardRef(
   (
     {
       inputType = 'text',
+      id = 'genericInput',
       label = 'Generic label',
       labelPosition = 'left',
       passwordToggle = false,
@@ -60,6 +63,7 @@ export const GenericInput: React.FC<GenericInputProps> = forwardRef(
       onChange,
       required,
       disabled,
+      ...baseInputProps
     },
     ref,
   ) => {
@@ -70,9 +74,10 @@ export const GenericInput: React.FC<GenericInputProps> = forwardRef(
       <LabelPasswordInputContainer
         labelPosition={labelPosition}
         gapSize={gapSize}>
-        <label>{label}</label>
+        <label htmlFor={id}>{label}</label>
         <InputIconContainer>
           <StyledInput
+            id={id}
             ref={ref}
             type={inputType}
             fontSize={fontSize}
@@ -92,6 +97,7 @@ export const GenericInput: React.FC<GenericInputProps> = forwardRef(
             onChange={onChange}
             required={required}
             disabled={disabled}
+            {...baseInputProps}
             data-testid="generic-input"
           />
           {passwordToggle && (

--- a/src/components/Inputs/GenericInput.tsx
+++ b/src/components/Inputs/GenericInput.tsx
@@ -96,6 +96,7 @@ export const GenericInput: React.FC<GenericInputProps> = forwardRef(
           />
           {passwordToggle && (
             <ViewPasswordButton
+              type="button"
               onClick={() => setPasswordIsVisible(prev => !prev)}
               svgColor={svgColor}
               focusBorderColor={focusBorderColor}

--- a/src/components/Inputs/GenericInput.tsx
+++ b/src/components/Inputs/GenericInput.tsx
@@ -67,8 +67,12 @@ export const GenericInput: React.FC<GenericInputProps> = forwardRef(
     },
     ref,
   ) => {
-    const [passwordIsVisible, setPasswordIsVisible] =
-      useState<boolean>(passwordToggle);
+    const [passwordIsVisible, setPasswordIsVisible] = useState(passwordToggle);
+    const toggleView = passwordIsVisible ? (
+      <ViewPasswordIcon />
+    ) : (
+      <HidePasswordIcon />
+    );
 
     return (
       <LabelPasswordInputContainer
@@ -107,7 +111,7 @@ export const GenericInput: React.FC<GenericInputProps> = forwardRef(
               svgColor={svgColor}
               focusBorderColor={focusBorderColor}
               focusBorderWidth={focusBorderWidth}>
-              {passwordIsVisible ? <ViewPasswordIcon /> : <HidePasswordIcon />}
+              {toggleView}
             </ViewPasswordButton>
           )}
         </InputIconContainer>

--- a/src/components/Inputs/GenericInput.tsx
+++ b/src/components/Inputs/GenericInput.tsx
@@ -1,11 +1,11 @@
 import styled from '@emotion/styled';
-import React, { InputHTMLAttributes, useState } from 'react';
+import React, { InputHTMLAttributes, forwardRef, useState } from 'react';
 import { pxToRem } from '../../utils';
 import ViewPasswordIcon from '../../assets/svg/icons/view-password-icon.svg';
 import HidePasswordIcon from '../../assets/svg/icons/hide-password-icon.svg';
 
 export type GenericLabelPositions = 'top' | 'right' | 'bottom' | 'left';
-export type GenericTypes = 'text' | 'email' | 'password';
+export type GenericTypes = 'text' | 'email' | 'password' | 'radio';
 
 export interface GenericInputProps
   extends InputHTMLAttributes<HTMLInputElement> {
@@ -32,77 +32,85 @@ export interface GenericInputProps
   readonly disabled?: boolean;
   readonly required?: boolean;
   readonly onChange?: React.ChangeEventHandler<HTMLInputElement>;
+  readonly ref?: React.ForwardedRef<HTMLInputElement>;
 }
 
-export const GenericInput: React.FC<GenericInputProps> = ({
-  inputType = 'text',
-  label = 'Generic label',
-  labelPosition = 'left',
-  passwordToggle = false,
-  gapSize,
-  fontSize,
-  fontColor,
-  svgColor,
-  placeholder = 'Enter text',
-  placeholderColor,
-  boxShadowColor,
-  borderColor,
-  focusBorderColor,
-  focusBorderWidth,
-  width,
-  height,
-  minTextLength,
-  maxTextLength,
-  spellcheck,
-  pattern,
-  onChange,
-  required,
-  disabled,
-  ...rest
-}) => {
-  const [passwordIsVisible, setPasswordIsVisible] =
-    useState<boolean>(passwordToggle);
-  return (
-    <LabelPasswordInputContainer
-      labelPosition={labelPosition}
-      gapSize={gapSize}>
-      <label>{label}</label>
-      <InputIconContainer>
-        <StyledInput
-          type={inputType}
-          fontSize={fontSize}
-          fontColor={fontColor}
-          boxShadowColor={boxShadowColor}
-          borderColor={borderColor}
-          focusBorderColor={focusBorderColor}
-          focusBorderWidth={focusBorderWidth}
-          width={width}
-          height={height}
-          placeholder={placeholder}
-          placeholderColor={placeholderColor}
-          minLength={minTextLength}
-          maxLength={maxTextLength}
-          spellCheck={spellcheck}
-          pattern={pattern}
-          onChange={onChange}
-          required={required}
-          disabled={disabled}
-          data-testid="generic-input"
-          {...rest}
-        />
-        {passwordToggle && (
-          <ViewPasswordButton
-            onClick={() => setPasswordIsVisible(prev => !prev)}
-            svgColor={svgColor}
+export const GenericInput: React.FC<GenericInputProps> = forwardRef(
+  function GenericInput(
+    {
+      inputType = 'text',
+      label = 'Generic label',
+      labelPosition = 'left',
+      passwordToggle = false,
+      gapSize,
+      fontSize,
+      fontColor,
+      svgColor,
+      placeholder = 'Enter text',
+      placeholderColor,
+      boxShadowColor,
+      borderColor,
+      focusBorderColor,
+      focusBorderWidth,
+      width,
+      height,
+      minTextLength,
+      maxTextLength,
+      spellcheck,
+      pattern,
+      onChange,
+      required,
+      disabled,
+      ...rest
+    },
+    ref,
+  ) {
+    const [passwordIsVisible, setPasswordIsVisible] =
+      useState<boolean>(passwordToggle);
+
+    return (
+      <LabelPasswordInputContainer
+        labelPosition={labelPosition}
+        gapSize={gapSize}>
+        <label>{label}</label>
+        <InputIconContainer>
+          <StyledInput
+            ref={ref}
+            type={inputType}
+            fontSize={fontSize}
+            fontColor={fontColor}
+            boxShadowColor={boxShadowColor}
+            borderColor={borderColor}
             focusBorderColor={focusBorderColor}
-            focusBorderWidth={focusBorderWidth}>
-            {passwordIsVisible ? <ViewPasswordIcon /> : <HidePasswordIcon />}
-          </ViewPasswordButton>
-        )}
-      </InputIconContainer>
-    </LabelPasswordInputContainer>
-  );
-};
+            focusBorderWidth={focusBorderWidth}
+            width={width}
+            height={height}
+            placeholder={placeholder}
+            placeholderColor={placeholderColor}
+            minLength={minTextLength}
+            maxLength={maxTextLength}
+            spellCheck={spellcheck}
+            pattern={pattern}
+            onChange={onChange}
+            required={required}
+            disabled={disabled}
+            data-testid="generic-input"
+            {...rest}
+          />
+          {passwordToggle && (
+            <ViewPasswordButton
+              onClick={() => setPasswordIsVisible(prev => !prev)}
+              svgColor={svgColor}
+              focusBorderColor={focusBorderColor}
+              focusBorderWidth={focusBorderWidth}>
+              {passwordIsVisible ? <ViewPasswordIcon /> : <HidePasswordIcon />}
+            </ViewPasswordButton>
+          )}
+        </InputIconContainer>
+      </LabelPasswordInputContainer>
+    );
+  },
+);
 
 const LabelPasswordInputContainer = styled.div<{
   labelPosition: GenericLabelPositions;

--- a/src/components/Inputs/GenericInput.tsx
+++ b/src/components/Inputs/GenericInput.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled';
-import React, { InputHTMLAttributes, forwardRef, useState } from 'react';
+import React, { forwardRef, useState } from 'react';
 import { pxToRem } from '../../utils';
 import ViewPasswordIcon from '../../assets/svg/icons/view-password-icon.svg';
 import HidePasswordIcon from '../../assets/svg/icons/hide-password-icon.svg';
@@ -7,8 +7,7 @@ import HidePasswordIcon from '../../assets/svg/icons/hide-password-icon.svg';
 export type GenericLabelPositions = 'top' | 'right' | 'bottom' | 'left';
 export type GenericTypes = 'text' | 'email' | 'password' | 'radio';
 
-export interface GenericInputProps
-  extends InputHTMLAttributes<HTMLInputElement> {
+export interface GenericInputProps {
   readonly inputType: GenericTypes;
   readonly label?: string;
   readonly labelPosition?: GenericLabelPositions;
@@ -36,7 +35,7 @@ export interface GenericInputProps
 }
 
 export const GenericInput: React.FC<GenericInputProps> = forwardRef(
-  function GenericInput(
+  (
     {
       inputType = 'text',
       label = 'Generic label',
@@ -61,10 +60,9 @@ export const GenericInput: React.FC<GenericInputProps> = forwardRef(
       onChange,
       required,
       disabled,
-      ...rest
     },
     ref,
-  ) {
+  ) => {
     const [passwordIsVisible, setPasswordIsVisible] =
       useState<boolean>(passwordToggle);
 
@@ -95,7 +93,6 @@ export const GenericInput: React.FC<GenericInputProps> = forwardRef(
             required={required}
             disabled={disabled}
             data-testid="generic-input"
-            {...rest}
           />
           {passwordToggle && (
             <ViewPasswordButton
@@ -111,6 +108,8 @@ export const GenericInput: React.FC<GenericInputProps> = forwardRef(
     );
   },
 );
+
+GenericInput.displayName = 'GenericInput';
 
 const LabelPasswordInputContainer = styled.div<{
   labelPosition: GenericLabelPositions;

--- a/src/components/Inputs/NumberInput.tsx
+++ b/src/components/Inputs/NumberInput.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { InputHTMLAttributes, useState } from 'react';
 import styled from '@emotion/styled';
 import { pxToRem } from '../../utils';
 import ArrowUpIcon from '../../assets/svg/icons/arrow-up-icon.svg';
@@ -6,7 +6,8 @@ import ArrowDownIcon from '../../assets/svg/icons/arrow-down-icon.svg';
 
 export type NumberLabelPositions = 'top' | 'right' | 'bottom' | 'left';
 
-export interface NumberInputProps {
+export interface NumberInputProps
+  extends InputHTMLAttributes<HTMLInputElement> {
   readonly label?: string;
   readonly labelPosition?: NumberLabelPositions;
   readonly gapSize?: number;
@@ -46,6 +47,7 @@ export const NumberInput: React.FC<NumberInputProps> = ({
   maxNumberValue = 20,
   required,
   disabled,
+  ...rest
 }) => {
   const [inputValue, setInputValue] = useState(defaultValue);
 
@@ -89,6 +91,7 @@ export const NumberInput: React.FC<NumberInputProps> = ({
           required={required}
           disabled={disabled}
           onChange={onChangeHandler}
+          {...rest}
         />
         <ArrowsContainer>
           <ArrowButton

--- a/src/components/Inputs/NumberInput.tsx
+++ b/src/components/Inputs/NumberInput.tsx
@@ -1,4 +1,4 @@
-import React, { InputHTMLAttributes, forwardRef, useState } from 'react';
+import React, { forwardRef, useState } from 'react';
 import styled from '@emotion/styled';
 import { pxToRem } from '../../utils';
 import ArrowUpIcon from '../../assets/svg/icons/arrow-up-icon.svg';
@@ -6,8 +6,7 @@ import ArrowDownIcon from '../../assets/svg/icons/arrow-down-icon.svg';
 
 export type NumberLabelPositions = 'top' | 'right' | 'bottom' | 'left';
 
-export interface NumberInputProps
-  extends InputHTMLAttributes<HTMLInputElement> {
+export interface NumberInputProps {
   readonly label?: string;
   readonly labelPosition?: NumberLabelPositions;
   readonly gapSize?: number;
@@ -30,7 +29,7 @@ export interface NumberInputProps
 }
 
 export const NumberInput: React.FC<NumberInputProps> = forwardRef(
-  function NumberInput(
+  (
     {
       label = 'number input',
       labelPosition,
@@ -50,10 +49,9 @@ export const NumberInput: React.FC<NumberInputProps> = forwardRef(
       maxNumberValue = 20,
       required,
       disabled,
-      ...rest
     },
     ref,
-  ) {
+  ) => {
     const [inputValue, setInputValue] = useState(defaultValue);
 
     const onChangeHandler = (e: { target: { value: string | number } }) =>
@@ -99,7 +97,6 @@ export const NumberInput: React.FC<NumberInputProps> = forwardRef(
             required={required}
             disabled={disabled}
             onChange={onChangeHandler}
-            {...rest}
           />
           <ArrowsContainer>
             <ArrowButton
@@ -124,6 +121,8 @@ export const NumberInput: React.FC<NumberInputProps> = forwardRef(
     );
   },
 );
+
+NumberInput.displayName = 'NumberInput';
 
 const LabelPasswordInputContainer = styled.div<{
   labelPosition?: NumberLabelPositions;

--- a/src/components/Inputs/NumberInput.tsx
+++ b/src/components/Inputs/NumberInput.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, useState } from 'react';
+import React, { InputHTMLAttributes, forwardRef, useState } from 'react';
 import styled from '@emotion/styled';
 import { pxToRem } from '../../utils';
 import ArrowUpIcon from '../../assets/svg/icons/arrow-up-icon.svg';
@@ -6,7 +6,8 @@ import ArrowDownIcon from '../../assets/svg/icons/arrow-down-icon.svg';
 
 export type NumberLabelPositions = 'top' | 'right' | 'bottom' | 'left';
 
-export interface NumberInputProps {
+export interface NumberInputProps
+  extends InputHTMLAttributes<HTMLInputElement> {
   readonly label?: string;
   readonly labelPosition?: NumberLabelPositions;
   readonly gapSize?: number;
@@ -26,11 +27,13 @@ export interface NumberInputProps {
   readonly disabled?: boolean;
   readonly required?: boolean;
   readonly ref?: React.ForwardedRef<HTMLInputElement>;
+  readonly id?: string;
 }
 
 export const NumberInput: React.FC<NumberInputProps> = forwardRef(
   (
     {
+      id = 'NumberInput',
       label = 'number input',
       labelPosition,
       gapSize,
@@ -49,6 +52,7 @@ export const NumberInput: React.FC<NumberInputProps> = forwardRef(
       maxNumberValue = 20,
       required,
       disabled,
+      ...baseInputProps
     },
     ref,
   ) => {
@@ -77,11 +81,12 @@ export const NumberInput: React.FC<NumberInputProps> = forwardRef(
       <LabelPasswordInputContainer
         labelPosition={labelPosition}
         gapSize={gapSize}>
-        <label>{label}</label>
+        <label htmlFor={id}>{label}</label>
         <InputAndArrowsContainer
           height={height}
           boxShadowColor={boxShadowColor}>
           <StyledInput
+            id={id}
             ref={ref}
             type="number"
             fontSize={fontSize}
@@ -97,6 +102,7 @@ export const NumberInput: React.FC<NumberInputProps> = forwardRef(
             required={required}
             disabled={disabled}
             onChange={onChangeHandler}
+            {...baseInputProps}
           />
           <ArrowsContainer>
             <ArrowButton

--- a/src/components/Inputs/NumberInput.tsx
+++ b/src/components/Inputs/NumberInput.tsx
@@ -1,4 +1,4 @@
-import React, { InputHTMLAttributes, useState } from 'react';
+import React, { InputHTMLAttributes, forwardRef, useState } from 'react';
 import styled from '@emotion/styled';
 import { pxToRem } from '../../utils';
 import ArrowUpIcon from '../../assets/svg/icons/arrow-up-icon.svg';
@@ -26,95 +26,104 @@ export interface NumberInputProps
   readonly maxNumberValue?: number;
   readonly disabled?: boolean;
   readonly required?: boolean;
+  readonly ref?: React.ForwardedRef<HTMLInputElement>;
 }
 
-export const NumberInput: React.FC<NumberInputProps> = ({
-  label = 'number input',
-  labelPosition,
-  gapSize,
-  fontSize,
-  fontColor,
-  boxShadowColor,
-  focusBorderColor,
-  focusBorderWidth = 1,
-  width,
-  height,
-  arrowColor,
-  readonly = false,
-  defaultValue = 0,
-  step = 1,
-  minNumberValue = 0,
-  maxNumberValue = 20,
-  required,
-  disabled,
-  ...rest
-}) => {
-  const [inputValue, setInputValue] = useState(defaultValue);
+export const NumberInput: React.FC<NumberInputProps> = forwardRef(
+  function NumberInput(
+    {
+      label = 'number input',
+      labelPosition,
+      gapSize,
+      fontSize,
+      fontColor,
+      boxShadowColor,
+      focusBorderColor,
+      focusBorderWidth = 1,
+      width,
+      height,
+      arrowColor,
+      readonly = false,
+      defaultValue = 0,
+      step = 1,
+      minNumberValue = 0,
+      maxNumberValue = 20,
+      required,
+      disabled,
+      ...rest
+    },
+    ref,
+  ) {
+    const [inputValue, setInputValue] = useState(defaultValue);
 
-  const onChangeHandler = (e: { target: { value: string | number } }) =>
-    setInputValue(+e.target.value);
+    const onChangeHandler = (e: { target: { value: string | number } }) =>
+      setInputValue(+e.target.value);
 
-  const handleIncrement = () =>
-    inputValue < maxNumberValue
-      ? setInputValue(prev => prev + step)
-      : setInputValue(maxNumberValue);
+    const handleIncrement = () =>
+      inputValue < maxNumberValue
+        ? setInputValue(prev => prev + step)
+        : setInputValue(maxNumberValue);
 
-  const handleDecrement = () => {
-    if (inputValue > maxNumberValue) {
-      setInputValue(maxNumberValue);
-    }
-    if (inputValue > minNumberValue) {
-      setInputValue(prev => prev - step);
-    } else {
-      setInputValue(minNumberValue);
-    }
-  };
+    const handleDecrement = () => {
+      if (inputValue > maxNumberValue) {
+        setInputValue(maxNumberValue);
+      }
+      if (inputValue > minNumberValue) {
+        setInputValue(prev => prev - step);
+      } else {
+        setInputValue(minNumberValue);
+      }
+    };
 
-  return (
-    <LabelPasswordInputContainer
-      labelPosition={labelPosition}
-      gapSize={gapSize}>
-      <label>{label}</label>
-      <InputAndArrowsContainer height={height} boxShadowColor={boxShadowColor}>
-        <StyledInput
-          type="number"
-          fontSize={fontSize}
-          fontColor={fontColor}
-          width={width}
-          min={minNumberValue}
-          max={maxNumberValue}
-          step={step}
-          value={inputValue.toFixed(0)}
-          readOnly={readonly}
-          focusBorderColor={focusBorderColor}
-          focusBorderWidth={focusBorderWidth}
-          required={required}
-          disabled={disabled}
-          onChange={onChangeHandler}
-          {...rest}
-        />
-        <ArrowsContainer>
-          <ArrowButton
-            arrowColor={arrowColor}
+    return (
+      <LabelPasswordInputContainer
+        labelPosition={labelPosition}
+        gapSize={gapSize}>
+        <label>{label}</label>
+        <InputAndArrowsContainer
+          height={height}
+          boxShadowColor={boxShadowColor}>
+          <StyledInput
+            ref={ref}
+            type="number"
+            fontSize={fontSize}
+            fontColor={fontColor}
+            width={width}
+            min={minNumberValue}
+            max={maxNumberValue}
+            step={step}
+            value={inputValue.toFixed(0)}
+            readOnly={readonly}
             focusBorderColor={focusBorderColor}
             focusBorderWidth={focusBorderWidth}
+            required={required}
             disabled={disabled}
-            onClick={handleIncrement}>
-            <ArrowUpIcon />
-          </ArrowButton>
-          <ArrowButton
-            arrowColor={arrowColor}
-            focusBorderColor={focusBorderColor}
-            focusBorderWidth={focusBorderWidth}
-            disabled={disabled}
-            onClick={handleDecrement}>
-            <ArrowDownIcon />
-          </ArrowButton>
-        </ArrowsContainer>
-      </InputAndArrowsContainer>
-    </LabelPasswordInputContainer>
-  );
-};
+            onChange={onChangeHandler}
+            {...rest}
+          />
+          <ArrowsContainer>
+            <ArrowButton
+              arrowColor={arrowColor}
+              focusBorderColor={focusBorderColor}
+              focusBorderWidth={focusBorderWidth}
+              disabled={disabled}
+              onClick={handleIncrement}>
+              <ArrowUpIcon />
+            </ArrowButton>
+            <ArrowButton
+              arrowColor={arrowColor}
+              focusBorderColor={focusBorderColor}
+              focusBorderWidth={focusBorderWidth}
+              disabled={disabled}
+              onClick={handleDecrement}>
+              <ArrowDownIcon />
+            </ArrowButton>
+          </ArrowsContainer>
+        </InputAndArrowsContainer>
+      </LabelPasswordInputContainer>
+    );
+  },
+);
 
 const LabelPasswordInputContainer = styled.div<{
   labelPosition?: NumberLabelPositions;

--- a/src/components/Inputs/PasswordInput.tsx
+++ b/src/components/Inputs/PasswordInput.tsx
@@ -1,12 +1,13 @@
 import styled from '@emotion/styled';
-import React, { useState } from 'react';
+import React, { InputHTMLAttributes, useState } from 'react';
 import { pxToRem } from '../../utils';
 import ViewPasswordIcon from '../../assets/svg/icons/view-password-icon.svg';
 import HidePasswordIcon from '../../assets/svg/icons/hide-password-icon.svg';
 
 export type PasswordLabelPositions = 'top' | 'right' | 'bottom' | 'left';
 
-export interface PasswordInputProps {
+export interface PasswordInputProps
+  extends InputHTMLAttributes<HTMLInputElement> {
   readonly label?: string;
   readonly labelPosition?: PasswordLabelPositions;
   readonly gapSize?: number;
@@ -50,6 +51,7 @@ export const PasswordInput: React.FC<PasswordInputProps> = ({
   onChange,
   required,
   disabled,
+  ...rest
 }) => {
   const [passwordIsVisible, setPasswordIsVisible] = useState<boolean>(false);
 
@@ -78,6 +80,7 @@ export const PasswordInput: React.FC<PasswordInputProps> = ({
           required={required}
           disabled={disabled}
           data-testid="password-input"
+          {...rest}
         />
         <ViewPasswordButton
           onClick={() => setPasswordIsVisible(prev => !prev)}

--- a/src/components/Inputs/PasswordInput.tsx
+++ b/src/components/Inputs/PasswordInput.tsx
@@ -60,7 +60,12 @@ export const PasswordInput: React.FC<PasswordInputProps> = forwardRef(
     },
     ref,
   ) => {
-    const [passwordIsVisible, setPasswordIsVisible] = useState<boolean>(false);
+    const [passwordIsVisible, setPasswordIsVisible] = useState(false);
+    const toggleView = passwordIsVisible ? (
+      <ViewPasswordIcon />
+    ) : (
+      <HidePasswordIcon />
+    );
 
     return (
       <LabelPasswordInputContainer
@@ -97,7 +102,7 @@ export const PasswordInput: React.FC<PasswordInputProps> = forwardRef(
             svgColor={svgColor}
             focusBorderColor={focusBorderColor}
             focusBorderWidth={focusBorderWidth}>
-            {passwordIsVisible ? <ViewPasswordIcon /> : <HidePasswordIcon />}
+            {toggleView}
           </ViewPasswordButton>
         </InputIconContainer>
       </LabelPasswordInputContainer>

--- a/src/components/Inputs/PasswordInput.tsx
+++ b/src/components/Inputs/PasswordInput.tsx
@@ -1,13 +1,12 @@
 import styled from '@emotion/styled';
-import React, { InputHTMLAttributes, useState, forwardRef } from 'react';
+import React, { useState, forwardRef } from 'react';
 import { pxToRem } from '../../utils';
 import ViewPasswordIcon from '../../assets/svg/icons/view-password-icon.svg';
 import HidePasswordIcon from '../../assets/svg/icons/hide-password-icon.svg';
 
 export type PasswordLabelPositions = 'top' | 'right' | 'bottom' | 'left';
 
-export interface PasswordInputProps
-  extends InputHTMLAttributes<HTMLInputElement> {
+export interface PasswordInputProps {
   readonly label?: string;
   readonly labelPosition?: PasswordLabelPositions;
   readonly gapSize?: number;
@@ -32,7 +31,7 @@ export interface PasswordInputProps
 }
 
 export const PasswordInput: React.FC<PasswordInputProps> = forwardRef(
-  function PasswordInput(
+  (
     {
       label = 'Password Label',
       labelPosition = 'left',
@@ -54,10 +53,9 @@ export const PasswordInput: React.FC<PasswordInputProps> = forwardRef(
       onChange,
       required,
       disabled,
-      ...rest
     },
     ref,
-  ) {
+  ) => {
     const [passwordIsVisible, setPasswordIsVisible] = useState<boolean>(false);
 
     return (
@@ -86,7 +84,6 @@ export const PasswordInput: React.FC<PasswordInputProps> = forwardRef(
             required={required}
             disabled={disabled}
             data-testid="password-input"
-            {...rest}
           />
           <ViewPasswordButton
             onClick={() => setPasswordIsVisible(prev => !prev)}
@@ -100,6 +97,8 @@ export const PasswordInput: React.FC<PasswordInputProps> = forwardRef(
     );
   },
 );
+
+PasswordInput.displayName = 'PasswordInput';
 
 const LabelPasswordInputContainer = styled.div<{
   labelPosition: PasswordLabelPositions;

--- a/src/components/Inputs/PasswordInput.tsx
+++ b/src/components/Inputs/PasswordInput.tsx
@@ -1,12 +1,13 @@
 import styled from '@emotion/styled';
-import React, { useState, forwardRef } from 'react';
+import React, { useState, forwardRef, InputHTMLAttributes } from 'react';
 import { pxToRem } from '../../utils';
 import ViewPasswordIcon from '../../assets/svg/icons/view-password-icon.svg';
 import HidePasswordIcon from '../../assets/svg/icons/hide-password-icon.svg';
 
 export type PasswordLabelPositions = 'top' | 'right' | 'bottom' | 'left';
 
-export interface PasswordInputProps {
+export interface PasswordInputProps
+  extends InputHTMLAttributes<HTMLInputElement> {
   readonly label?: string;
   readonly labelPosition?: PasswordLabelPositions;
   readonly gapSize?: number;
@@ -28,11 +29,13 @@ export interface PasswordInputProps {
   readonly required?: boolean;
   readonly onChange?: React.ChangeEventHandler<HTMLInputElement>;
   readonly ref?: React.ForwardedRef<HTMLInputElement>;
+  readonly id?: string;
 }
 
 export const PasswordInput: React.FC<PasswordInputProps> = forwardRef(
   (
     {
+      id = 'passwordInput',
       label = 'Password Label',
       labelPosition = 'left',
       gapSize,
@@ -53,6 +56,7 @@ export const PasswordInput: React.FC<PasswordInputProps> = forwardRef(
       onChange,
       required,
       disabled,
+      ...baseInputProps
     },
     ref,
   ) => {
@@ -62,9 +66,10 @@ export const PasswordInput: React.FC<PasswordInputProps> = forwardRef(
       <LabelPasswordInputContainer
         labelPosition={labelPosition}
         gapSize={gapSize}>
-        <label>{label}</label>
+        <label htmlFor={id}>{label}</label>
         <InputIconContainer>
           <StyledPasswordInput
+            id={id}
             ref={ref}
             fontSize={fontSize}
             fontColor={fontColor}
@@ -83,6 +88,7 @@ export const PasswordInput: React.FC<PasswordInputProps> = forwardRef(
             onChange={onChange}
             required={required}
             disabled={disabled}
+            {...baseInputProps}
             data-testid="password-input"
           />
           <ViewPasswordButton

--- a/src/components/Inputs/PasswordInput.tsx
+++ b/src/components/Inputs/PasswordInput.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled';
-import React, { InputHTMLAttributes, useState } from 'react';
+import React, { InputHTMLAttributes, useState, forwardRef } from 'react';
 import { pxToRem } from '../../utils';
 import ViewPasswordIcon from '../../assets/svg/icons/view-password-icon.svg';
 import HidePasswordIcon from '../../assets/svg/icons/hide-password-icon.svg';
@@ -28,71 +28,78 @@ export interface PasswordInputProps
   readonly disabled?: boolean;
   readonly required?: boolean;
   readonly onChange?: React.ChangeEventHandler<HTMLInputElement>;
+  readonly ref?: React.ForwardedRef<HTMLInputElement>;
 }
 
-export const PasswordInput: React.FC<PasswordInputProps> = ({
-  label = 'Password Label',
-  labelPosition = 'left',
-  gapSize,
-  fontSize,
-  fontColor,
-  placeholder = '••••••••••••••••••••',
-  placeholderColor,
-  svgColor,
-  boxShadowColor,
-  borderColor,
-  focusBorderColor,
-  focusBorderWidth,
-  width,
-  height,
-  minPasswordLength = 1,
-  maxPasswordLength = 20,
-  pattern,
-  onChange,
-  required,
-  disabled,
-  ...rest
-}) => {
-  const [passwordIsVisible, setPasswordIsVisible] = useState<boolean>(false);
+export const PasswordInput: React.FC<PasswordInputProps> = forwardRef(
+  function PasswordInput(
+    {
+      label = 'Password Label',
+      labelPosition = 'left',
+      gapSize,
+      fontSize,
+      fontColor,
+      placeholder = '••••••••••••••••••••',
+      placeholderColor,
+      svgColor,
+      boxShadowColor,
+      borderColor,
+      focusBorderColor,
+      focusBorderWidth,
+      width,
+      height,
+      minPasswordLength = 1,
+      maxPasswordLength = 20,
+      pattern,
+      onChange,
+      required,
+      disabled,
+      ...rest
+    },
+    ref,
+  ) {
+    const [passwordIsVisible, setPasswordIsVisible] = useState<boolean>(false);
 
-  return (
-    <LabelPasswordInputContainer
-      labelPosition={labelPosition}
-      gapSize={gapSize}>
-      <label>{label}</label>
-      <InputIconContainer>
-        <StyledPasswordInput
-          fontSize={fontSize}
-          fontColor={fontColor}
-          boxShadowColor={boxShadowColor}
-          borderColor={borderColor}
-          focusBorderColor={focusBorderColor}
-          focusBorderWidth={focusBorderWidth}
-          width={width}
-          height={height}
-          placeholder={placeholder}
-          placeholderColor={placeholderColor}
-          type={passwordIsVisible ? 'text' : 'password'}
-          min={minPasswordLength}
-          maxLength={maxPasswordLength}
-          pattern={pattern}
-          onChange={onChange}
-          required={required}
-          disabled={disabled}
-          data-testid="password-input"
-          {...rest}
-        />
-        <ViewPasswordButton
-          onClick={() => setPasswordIsVisible(prev => !prev)}
-          svgColor={svgColor}
-          focusBorderColor={focusBorderColor}
-          focusBorderWidth={focusBorderWidth}>
-          {passwordIsVisible ? <ViewPasswordIcon /> : <HidePasswordIcon />}
-        </ViewPasswordButton>
-      </InputIconContainer>
-    </LabelPasswordInputContainer>
-  );
-};
+    return (
+      <LabelPasswordInputContainer
+        labelPosition={labelPosition}
+        gapSize={gapSize}>
+        <label>{label}</label>
+        <InputIconContainer>
+          <StyledPasswordInput
+            ref={ref}
+            fontSize={fontSize}
+            fontColor={fontColor}
+            boxShadowColor={boxShadowColor}
+            borderColor={borderColor}
+            focusBorderColor={focusBorderColor}
+            focusBorderWidth={focusBorderWidth}
+            width={width}
+            height={height}
+            placeholder={placeholder}
+            placeholderColor={placeholderColor}
+            type={passwordIsVisible ? 'text' : 'password'}
+            min={minPasswordLength}
+            maxLength={maxPasswordLength}
+            pattern={pattern}
+            onChange={onChange}
+            required={required}
+            disabled={disabled}
+            data-testid="password-input"
+            {...rest}
+          />
+          <ViewPasswordButton
+            onClick={() => setPasswordIsVisible(prev => !prev)}
+            svgColor={svgColor}
+            focusBorderColor={focusBorderColor}
+            focusBorderWidth={focusBorderWidth}>
+            {passwordIsVisible ? <ViewPasswordIcon /> : <HidePasswordIcon />}
+          </ViewPasswordButton>
+        </InputIconContainer>
+      </LabelPasswordInputContainer>
+    );
+  },
+);
 
 const LabelPasswordInputContainer = styled.div<{
   labelPosition: PasswordLabelPositions;

--- a/src/components/Inputs/PasswordInput.tsx
+++ b/src/components/Inputs/PasswordInput.tsx
@@ -86,6 +86,7 @@ export const PasswordInput: React.FC<PasswordInputProps> = forwardRef(
             data-testid="password-input"
           />
           <ViewPasswordButton
+            type="button"
             onClick={() => setPasswordIsVisible(prev => !prev)}
             svgColor={svgColor}
             focusBorderColor={focusBorderColor}

--- a/src/components/Inputs/TextInput.tsx
+++ b/src/components/Inputs/TextInput.tsx
@@ -1,10 +1,10 @@
 import styled from '@emotion/styled';
-import React, { InputHTMLAttributes } from 'react';
+import React, { forwardRef } from 'react';
 import { pxToRem } from '../../utils';
 
 export type TextLabelPositions = 'top' | 'right' | 'bottom' | 'left';
 
-export interface TextInputProps extends InputHTMLAttributes<HTMLInputElement> {
+export interface TextInputProps {
   readonly label?: string;
   readonly labelPosition?: TextLabelPositions;
   readonly gapSize?: number;
@@ -25,57 +25,66 @@ export interface TextInputProps extends InputHTMLAttributes<HTMLInputElement> {
   readonly disabled?: boolean;
   readonly required?: boolean;
   readonly onChange?: React.ChangeEventHandler<HTMLInputElement>;
+  readonly ref?: React.ForwardedRef<HTMLInputElement>;
 }
 
-export const TextInput: React.FC<TextInputProps> = ({
-  label = 'Text label',
-  labelPosition = 'left',
-  gapSize,
-  fontSize,
-  fontColor,
-  placeholder = 'Enter text',
-  placeholderColor,
-  boxShadowColor,
-  borderColor,
-  focusBorderColor,
-  focusBorderWidth,
-  width,
-  height,
-  minTextLength,
-  maxTextLength,
-  spellcheck,
-  pattern,
-  onChange,
-  required,
-  disabled,
-  ...rest
-}) => (
-  <LabelPasswordInputContainer labelPosition={labelPosition} gapSize={gapSize}>
-    <label>{label}</label>
-    <StyledInput
-      fontSize={fontSize}
-      fontColor={fontColor}
-      boxShadowColor={boxShadowColor}
-      borderColor={borderColor}
-      focusBorderColor={focusBorderColor}
-      focusBorderWidth={focusBorderWidth}
-      width={width}
-      height={height}
-      placeholder={placeholder}
-      placeholderColor={placeholderColor}
-      type="text"
-      minLength={minTextLength}
-      maxLength={maxTextLength}
-      spellCheck={spellcheck}
-      pattern={pattern}
-      onChange={onChange}
-      required={required}
-      disabled={disabled}
-      data-testid="text-input"
-      {...rest}
-    />
-  </LabelPasswordInputContainer>
+export const TextInput: React.FC<TextInputProps> = forwardRef(
+  (
+    {
+      label = 'Text label',
+      labelPosition = 'left',
+      gapSize,
+      fontSize,
+      fontColor,
+      placeholder = 'Enter text',
+      placeholderColor,
+      boxShadowColor,
+      borderColor,
+      focusBorderColor,
+      focusBorderWidth,
+      width,
+      height,
+      minTextLength,
+      maxTextLength,
+      spellcheck,
+      pattern,
+      onChange,
+      required,
+      disabled,
+    },
+    ref,
+  ) => (
+    <LabelPasswordInputContainer
+      labelPosition={labelPosition}
+      gapSize={gapSize}>
+      <label>{label}</label>
+      <StyledInput
+        ref={ref}
+        fontSize={fontSize}
+        fontColor={fontColor}
+        boxShadowColor={boxShadowColor}
+        borderColor={borderColor}
+        focusBorderColor={focusBorderColor}
+        focusBorderWidth={focusBorderWidth}
+        width={width}
+        height={height}
+        placeholder={placeholder}
+        placeholderColor={placeholderColor}
+        type="text"
+        minLength={minTextLength}
+        maxLength={maxTextLength}
+        spellCheck={spellcheck}
+        pattern={pattern}
+        onChange={onChange}
+        required={required}
+        disabled={disabled}
+        data-testid="text-input"
+      />
+    </LabelPasswordInputContainer>
+  ),
 );
+
+TextInput.displayName = 'TextInput';
 
 const LabelPasswordInputContainer = styled.div<{
   labelPosition: TextLabelPositions;

--- a/src/components/Inputs/TextInput.tsx
+++ b/src/components/Inputs/TextInput.tsx
@@ -1,10 +1,10 @@
 import styled from '@emotion/styled';
-import React, { forwardRef } from 'react';
+import React, { InputHTMLAttributes, forwardRef } from 'react';
 import { pxToRem } from '../../utils';
 
 export type TextLabelPositions = 'top' | 'right' | 'bottom' | 'left';
 
-export interface TextInputProps {
+export interface TextInputProps extends InputHTMLAttributes<HTMLInputElement> {
   readonly label?: string;
   readonly labelPosition?: TextLabelPositions;
   readonly gapSize?: number;
@@ -26,11 +26,13 @@ export interface TextInputProps {
   readonly required?: boolean;
   readonly onChange?: React.ChangeEventHandler<HTMLInputElement>;
   readonly ref?: React.ForwardedRef<HTMLInputElement>;
+  readonly id?: string;
 }
 
 export const TextInput: React.FC<TextInputProps> = forwardRef(
   (
     {
+      id = 'textInput',
       label = 'Text label',
       labelPosition = 'left',
       gapSize,
@@ -51,14 +53,16 @@ export const TextInput: React.FC<TextInputProps> = forwardRef(
       onChange,
       required,
       disabled,
+      ...baseInputProps
     },
     ref,
   ) => (
     <LabelPasswordInputContainer
       labelPosition={labelPosition}
       gapSize={gapSize}>
-      <label>{label}</label>
+      <label htmlFor={id}>{label}</label>
       <StyledInput
+        id={id}
         ref={ref}
         fontSize={fontSize}
         fontColor={fontColor}
@@ -78,6 +82,7 @@ export const TextInput: React.FC<TextInputProps> = forwardRef(
         onChange={onChange}
         required={required}
         disabled={disabled}
+        {...baseInputProps}
         data-testid="text-input"
       />
     </LabelPasswordInputContainer>

--- a/src/components/Inputs/TextInput.tsx
+++ b/src/components/Inputs/TextInput.tsx
@@ -1,10 +1,10 @@
 import styled from '@emotion/styled';
-import React from 'react';
+import React, { InputHTMLAttributes } from 'react';
 import { pxToRem } from '../../utils';
 
 export type TextLabelPositions = 'top' | 'right' | 'bottom' | 'left';
 
-export interface TextInputProps {
+export interface TextInputProps extends InputHTMLAttributes<HTMLInputElement> {
   readonly label?: string;
   readonly labelPosition?: TextLabelPositions;
   readonly gapSize?: number;
@@ -48,6 +48,7 @@ export const TextInput: React.FC<TextInputProps> = ({
   onChange,
   required,
   disabled,
+  ...rest
 }) => (
   <LabelPasswordInputContainer labelPosition={labelPosition} gapSize={gapSize}>
     <label>{label}</label>
@@ -71,6 +72,7 @@ export const TextInput: React.FC<TextInputProps> = ({
       required={required}
       disabled={disabled}
       data-testid="text-input"
+      {...rest}
     />
   </LabelPasswordInputContainer>
 );

--- a/src/stories/Button/Button.stories.tsx
+++ b/src/stories/Button/Button.stories.tsx
@@ -45,5 +45,5 @@ DisabledButton.args = {
   color: 'white',
   bgColor: 'purple',
   type: 'button',
-  isDisabled: true,
+  disabled: true,
 };

--- a/src/stories/Checkbox/Checkbox.stories.tsx
+++ b/src/stories/Checkbox/Checkbox.stories.tsx
@@ -8,7 +8,7 @@ export default {
   title: 'Components/Checkbox',
   component: Checkbox,
   argTypes: {
-    initialChecked: {
+    checked: {
       control: false,
     },
   },


### PR DESCRIPTION
🔥 Summary
Adds InputHTMLAttributes and forwardRef to Inputs

😤 Problem / Goals
Use of current ui-kit inputs in Factoring results this console warning
`Function components cannot be given refs. Attempts to access this ref will fail. Did you mean to use React.forwardRef()?`

🤓 Solution
Use of forwardRef gets rid of the warning and React-Hook-Form values are accessible on submit.


