### PR TITLE
Chore: Add Dependabot Configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+  - package-ecosystem: 'npm'
+    directory: '/'
+    schedule:
+      interval: 'daily'
+    open-pull-requests-limit: 5


### PR DESCRIPTION
### 🔥 Summary
This PR adds dependabot config to check for package upgrades daily

### 😤 Problem / Goals
- It's a challenge to always be up to date with our npm package versions

### 🤓 Solution
- Add dependabot config to check daily for potential upgrades
- Add dependabot config to double check PRs every week -- in order to update or remove
- Set max dependabot PRs to 5
