### PR TITLE
Fix:  styled import within jest environments

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,7 @@
 /** @type {import('ts-jest').JestConfigWithTsJest} */
 module.exports = {
   preset: 'ts-jest',
+  roots: ['<rootDir>/src'],
   testEnvironment: 'jsdom',
   transform: {
     '^.+\\.svg$': '<rootDir>/jest/svg-transform.js',
@@ -11,5 +12,6 @@ module.exports = {
     '\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$':
       '<rootDir>/jest/__mocks__/fileMock.js',
     '\\.(css|less|scss)$': '<rootDir>/jest/__mocks__/styleMock.js',
+    '^src/(.*)$': '<rootDir>/src/$1',
   },
 };

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,5 +1,5 @@
 import React, { InputHTMLAttributes } from 'react';
-import styled from '@emotion/styled';
+import styled from 'src/styled';
 import { pxToRem } from '../../utils';
 import { colors } from '../../theme/colors';
 

--- a/src/components/Cards/Card/Card.tsx
+++ b/src/components/Cards/Card/Card.tsx
@@ -1,4 +1,4 @@
-import styled from '@emotion/styled';
+import styled from 'src/styled';
 import React from 'react';
 import { subComponentHelper } from '../../../utils';
 

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -1,4 +1,4 @@
-import styled from '@emotion/styled';
+import styled from 'src/styled';
 import React, { InputHTMLAttributes, forwardRef, useState } from 'react';
 import { pxToRem } from '../../utils';
 import XSvg from '../../assets/svg/icons/x-icon.svg';

--- a/src/components/Heading/Heading.tsx
+++ b/src/components/Heading/Heading.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import styled from '@emotion/styled';
+import styled from 'src/styled';
 import { pxToRem } from '../../utils';
 import { defaultTheme } from '../../theme';
 

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import styled from '@emotion/styled';
+import styled from 'src/styled';
 import { pxToRem } from '../../utils';
 import BlocksIcon from '../../assets/svg/icons/blocks-icon.svg';
 import SearchIcon from '../../assets/svg/icons/search-icon.svg';

--- a/src/components/Inputs/EmailInput.tsx
+++ b/src/components/Inputs/EmailInput.tsx
@@ -1,4 +1,4 @@
-import styled from '@emotion/styled';
+import styled from 'src/styled';
 import React, { InputHTMLAttributes, forwardRef } from 'react';
 import { pxToRem } from '../../utils';
 

--- a/src/components/Inputs/GenericInput.tsx
+++ b/src/components/Inputs/GenericInput.tsx
@@ -1,4 +1,4 @@
-import styled from '@emotion/styled';
+import styled from 'src/styled';
 import React, { InputHTMLAttributes, forwardRef, useState } from 'react';
 import { pxToRem } from '../../utils';
 import ViewPasswordIcon from '../../assets/svg/icons/view-password-icon.svg';

--- a/src/components/Inputs/NumberInput.tsx
+++ b/src/components/Inputs/NumberInput.tsx
@@ -1,5 +1,5 @@
 import React, { InputHTMLAttributes, forwardRef, useState } from 'react';
-import styled from '@emotion/styled';
+import styled from 'src/styled';
 import { pxToRem } from '../../utils';
 import ArrowUpIcon from '../../assets/svg/icons/arrow-up-icon.svg';
 import ArrowDownIcon from '../../assets/svg/icons/arrow-down-icon.svg';

--- a/src/components/Inputs/PasswordInput.tsx
+++ b/src/components/Inputs/PasswordInput.tsx
@@ -1,4 +1,4 @@
-import styled from '@emotion/styled';
+import styled from 'src/styled';
 import React, { useState, forwardRef, InputHTMLAttributes } from 'react';
 import { pxToRem } from '../../utils';
 import ViewPasswordIcon from '../../assets/svg/icons/view-password-icon.svg';

--- a/src/components/Inputs/TextInput.tsx
+++ b/src/components/Inputs/TextInput.tsx
@@ -1,4 +1,4 @@
-import styled from '@emotion/styled';
+import styled from 'src/styled';
 import React, { InputHTMLAttributes, forwardRef } from 'react';
 import { pxToRem } from '../../utils';
 

--- a/src/components/Loader/Loader.tsx
+++ b/src/components/Loader/Loader.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import styled from '@emotion/styled';
+import styled from 'src/styled';
 import LoaderSVG from '../../assets/svg/icons/loader-icon.svg';
 
 export interface LoaderProps {

--- a/src/components/Logos/Logo.tsx
+++ b/src/components/Logos/Logo.tsx
@@ -1,4 +1,4 @@
-import styled from '@emotion/styled';
+import styled from 'src/styled';
 import React from 'react';
 import { pxToRem } from '../../utils';
 import BlockExplorerGradientLogo from '../../assets/svg/logos/block-explorer-gradient-logo.svg';

--- a/src/components/ProgressBar/ProgressBar.tsx
+++ b/src/components/ProgressBar/ProgressBar.tsx
@@ -1,4 +1,4 @@
-import styled from '@emotion/styled';
+import styled from 'src/styled';
 import React from 'react';
 
 import { defaultTheme } from '../../theme';

--- a/src/components/RadioButtons/Partials/BaseRadioButton.tsx
+++ b/src/components/RadioButtons/Partials/BaseRadioButton.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import styled from '@emotion/styled';
+import styled from 'src/styled';
 import { pxToRem } from '../../../utils';
 import { BaseRadioButtonProps } from '../RadioButtonTypes';
 import { defaultTheme } from '../../../theme';

--- a/src/components/RadioButtons/RadioButtonBox/RadioButtonBox.tsx
+++ b/src/components/RadioButtons/RadioButtonBox/RadioButtonBox.tsx
@@ -1,4 +1,4 @@
-import styled from '@emotion/styled';
+import styled from 'src/styled';
 import React from 'react';
 import { pxToRem } from '../../../utils';
 import XSvg from '../../../assets/svg/icons/x-icon.svg';

--- a/src/components/RadioButtons/RadioButtonBoxGroup.tsx
+++ b/src/components/RadioButtons/RadioButtonBoxGroup.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import styled from '@emotion/styled';
+import styled from 'src/styled';
 import { pxToRem } from '../../utils';
 import { RadioButtonBoxGroupOptions } from './RadioButtonTypes';
 import { RadioButtonBox } from './RadioButtonBox';

--- a/src/components/RadioButtons/RadioButtonGroup.tsx
+++ b/src/components/RadioButtons/RadioButtonGroup.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import styled from '@emotion/styled';
+import styled from 'src/styled';
 import { pxToRem } from '../../utils';
 import { OptionProps, RadioButtonLabelPositions } from './RadioButtonTypes';
 import { BaseRadioButton } from './Partials/BaseRadioButton';

--- a/src/components/SearchBar/SearchBar.tsx
+++ b/src/components/SearchBar/SearchBar.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import styled from '@emotion/styled';
+import styled from 'src/styled';
 import { PropsValue } from 'react-select';
 
 import { defaultTheme } from '../../theme';

--- a/src/components/Selectors/DropDownSelector.tsx
+++ b/src/components/Selectors/DropDownSelector.tsx
@@ -1,4 +1,4 @@
-import styled from '@emotion/styled';
+import styled from 'src/styled';
 import React, { ReactNode, useState } from 'react';
 import Select, { PropsValue } from 'react-select';
 import { defaultTheme } from '../../theme';

--- a/src/components/Tables/KeyValueTable/KeyValueTable.tsx
+++ b/src/components/Tables/KeyValueTable/KeyValueTable.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import styled from '@emotion/styled';
+import styled from 'src/styled';
 
 export interface KeyValueRow {
   key: React.Key;

--- a/src/components/Toggles/BaseToggle/BaseToggle.tsx
+++ b/src/components/Toggles/BaseToggle/BaseToggle.tsx
@@ -1,4 +1,4 @@
-import styled from '@emotion/styled';
+import styled from 'src/styled';
 import React from 'react';
 import { defaultTheme } from '../../../theme';
 

--- a/src/components/Toggles/ButtonToggle/ButtonToggle.tsx
+++ b/src/components/Toggles/ButtonToggle/ButtonToggle.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import styled from '@emotion/styled';
+import styled from 'src/styled';
 import { defaultTheme } from '../../../theme';
 
 export interface ButtonToggleProps {

--- a/src/components/Typography/Typography.tsx
+++ b/src/components/Typography/Typography.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import styled from '@emotion/styled';
+import styled from 'src/styled';
 import { pxToRem } from '../../utils';
 import { defaultTheme } from '../../theme';
 

--- a/src/stories/SearchBars/SearchBar.test.tsx
+++ b/src/stories/SearchBars/SearchBar.test.tsx
@@ -55,7 +55,7 @@ describe('SearchBar.stories', () => {
           // eslint-disable-next-line no-console
           console.log('clicked');
         }}
-        errorMessage={<p>Test Error</p>}
+        errorMessage={<span>Test Error</span>}
       />,
     );
 

--- a/src/styled.ts
+++ b/src/styled.ts
@@ -1,0 +1,8 @@
+import styled from '@emotion/styled';
+
+// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+const MyStyled: typeof styled =
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+  typeof styled === 'function' ? styled : (styled as any).default;
+
+export default MyStyled;


### PR DESCRIPTION
### 🔥 Summary
When running tests in jest environments of application that use this package; the import of `@emotion/styled` will cause tests to fail.

`styled.button is not a function` 
![236285672-b3f8a9e1-0982-4c53-8c75-4e02471b67d1](https://user-images.githubusercontent.com/26664788/236290763-28db8d3b-1c85-46f6-826b-475fedb9b4ea.png)

This error message might be confusing at first but it throwing at the first point `styled` is used in the bundled ui-kit:
<img width="377" alt="Screen Shot 2023-05-04 at 12 13 15 PM" src="https://user-images.githubusercontent.com/26664788/236292576-d4cf544d-2197-408a-be84-5da1a78b16b0.png">

### 😤 Problem / Goals
- `@emotion/styled` import is different within application jest environments

### 🤓 Solution
This solution is less than ideal but the best we got at the moment
- Switch imports to local file that handles both import 'paths'
