### PR TITLE
chore: version bump to 0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.1] - 2023-05-19
+
+### Fixed
+
+- Format of all instances of data-testid to use kebab-case
+
 ## [0.6.0] - 2023-05-05
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "casper-ui-kit",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Casper UI Kit",
   "main": "lib/index.js",
   "module": "lib/index.esm.js",


### PR DESCRIPTION
🔥 Summary
- Version bump to 0.6.1
