### PR TITLE
Feat/add cypress test ids

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -25,6 +25,7 @@ export interface ButtonProps extends InputHTMLAttributes<HTMLButtonElement> {
   readonly className?: string;
   readonly children: React.ReactNode;
   readonly onClick?: React.MouseEventHandler<HTMLButtonElement>;
+  readonly dataCy?: string;
 }
 
 export const Button: React.FC<ButtonProps> = ({
@@ -47,6 +48,7 @@ export const Button: React.FC<ButtonProps> = ({
   className,
   children,
   onClick,
+  dataCy,
   ...baseButtonProps
 }) => {
   return (
@@ -69,6 +71,7 @@ export const Button: React.FC<ButtonProps> = ({
       disabled={disabled}
       className={className}
       onClick={onClick}
+      data-cy={dataCy}
       {...baseButtonProps}>
       {children}
     </StyledButton>

--- a/src/components/Cards/Card/Card.tsx
+++ b/src/components/Cards/Card/Card.tsx
@@ -3,20 +3,24 @@ import React from 'react';
 import { subComponentHelper } from '../../../utils';
 
 export interface Children {
-  children: React.ReactNode;
+  readonly children: React.ReactNode;
 }
 
 export interface CardProps extends Children {
-  className?: string;
+  readonly className?: string;
+  readonly baseCardDataCy?: string;
 }
 
-export const Card = ({ children, className }: CardProps) => {
+export const Card = ({ children, className, baseCardDataCy }: CardProps) => {
   const subComponentList = Object.keys(Card);
 
   const subComponents = subComponentHelper(subComponentList, children);
 
   return (
-    <CardContentWrapper data-testid="base-card" className={className}>
+    <CardContentWrapper
+      data-testid="base-card"
+      data-cy={baseCardDataCy}
+      className={className}>
       {subComponents.map(component => component)}
     </CardContentWrapper>
   );

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -22,6 +22,7 @@ export interface CheckboxProps extends InputHTMLAttributes<HTMLInputElement> {
   readonly onChange?: React.ChangeEventHandler<HTMLInputElement>;
   readonly ref?: React.ForwardedRef<HTMLInputElement>;
   readonly id?: string;
+  readonly dataCy?: string;
 }
 
 export const Checkbox: React.FC<CheckboxProps> = forwardRef(
@@ -42,6 +43,7 @@ export const Checkbox: React.FC<CheckboxProps> = forwardRef(
       value,
       name,
       required,
+      dataCy,
       ...baseCheckboxProps
     },
     ref,
@@ -67,6 +69,7 @@ export const Checkbox: React.FC<CheckboxProps> = forwardRef(
             name={name}
             checked={checked}
             required={required}
+            data-cy={dataCy}
             {...baseCheckboxProps}
           />
           {isChecked && (

--- a/src/components/Heading/Heading.tsx
+++ b/src/components/Heading/Heading.tsx
@@ -13,13 +13,20 @@ export enum HeadingType {
 }
 
 export interface HeadingProps {
-  type: HeadingType;
-  color?: string;
-  font?: string;
-  fontWeight?: number;
-  fontSize?: number;
-  textAlign?: 'left' | 'right' | 'center' | 'justify' | 'initial' | 'inherit';
-  children: React.ReactNode;
+  readonly type: HeadingType;
+  readonly color?: string;
+  readonly font?: string;
+  readonly fontWeight?: number;
+  readonly fontSize?: number;
+  readonly textAlign?:
+    | 'left'
+    | 'right'
+    | 'center'
+    | 'justify'
+    | 'initial'
+    | 'inherit';
+  readonly children: React.ReactNode;
+  readonly dataCy?: string;
 }
 
 export const Heading: React.FC<HeadingProps> = ({
@@ -30,6 +37,7 @@ export const Heading: React.FC<HeadingProps> = ({
   fontSize,
   textAlign = 'inherit',
   children,
+  dataCy,
 }) => {
   const props = {
     textColor: color,
@@ -43,33 +51,61 @@ export const Heading: React.FC<HeadingProps> = ({
   switch (type) {
     case HeadingType.H1:
       props.fontSize = fontSize || 40;
-      return <H1 {...props}>{children}</H1>;
+      return (
+        <H1 {...props} data-cy={dataCy}>
+          {children}
+        </H1>
+      );
     case HeadingType.H2:
       props.fontSize = fontSize || 32;
-      return <H2 {...props}>{children}</H2>;
+      return (
+        <H2 {...props} data-cy={dataCy}>
+          {children}
+        </H2>
+      );
     case HeadingType.H3:
       props.fontSize = fontSize || 28;
       props.fontWeight =
         fontWeight || defaultTheme.typography.fontWeights.medium;
-      return <H3 {...props}>{children}</H3>;
+      return (
+        <H3 {...props} data-cy={dataCy}>
+          {children}
+        </H3>
+      );
     case HeadingType.H4:
       props.fontSize = fontSize || 24;
       props.fontWeight =
         fontWeight || defaultTheme.typography.fontWeights.medium;
-      return <H4 {...props}>{children}</H4>;
+      return (
+        <H4 {...props} data-cy={dataCy}>
+          {children}
+        </H4>
+      );
     case HeadingType.H5:
       props.fontWeight =
         fontWeight || defaultTheme.typography.fontWeights.normal;
       props.fontSize = fontSize || 20;
-      return <H5 {...props}>{children}</H5>;
+      return (
+        <H5 {...props} data-cy={dataCy}>
+          {children}
+        </H5>
+      );
     case HeadingType.H6:
       props.fontWeight =
         fontWeight || defaultTheme.typography.fontWeights.normal;
       props.fontSize = fontSize || 16;
-      return <H6 {...props}>{children}</H6>;
+      return (
+        <H6 {...props} data-cy={dataCy}>
+          {children}
+        </H6>
+      );
     default:
       props.fontSize = fontSize || 40;
-      return <H1 {...props}>{children}</H1>;
+      return (
+        <H1 {...props} data-cy={dataCy}>
+          {children}
+        </H1>
+      );
   }
 };
 

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -34,6 +34,7 @@ export interface IconProps {
   readonly color?: string;
   readonly stroke?: string;
   readonly strokeWidth?: number;
+  readonly dataCy?: string;
 }
 
 export const Icon: React.FC<IconProps> = ({
@@ -43,8 +44,9 @@ export const Icon: React.FC<IconProps> = ({
   color = 'white',
   stroke = 'grey',
   strokeWidth = 1,
+  dataCy,
 }) => (
-  <IconContainer data-testid="icon-component">
+  <IconContainer data-testid="icon-component" data-cy={dataCy}>
     <IconWrapper
       width={width}
       height={height}

--- a/src/components/Inputs/EmailInput.tsx
+++ b/src/components/Inputs/EmailInput.tsx
@@ -27,6 +27,7 @@ export interface EmailInputProps extends InputHTMLAttributes<HTMLInputElement> {
   readonly onChange?: React.ChangeEventHandler<HTMLInputElement>;
   readonly ref?: React.ForwardedRef<HTMLInputElement>;
   readonly id?: string;
+  readonly dataCy?: string;
 }
 
 export const EmailInput: React.FC<EmailInputProps> = forwardRef(
@@ -53,6 +54,7 @@ export const EmailInput: React.FC<EmailInputProps> = forwardRef(
       onChange,
       required,
       disabled,
+      dataCy,
       ...baseInputProps
     },
     ref,
@@ -84,8 +86,9 @@ export const EmailInput: React.FC<EmailInputProps> = forwardRef(
         onChange={onChange}
         required={required}
         disabled={disabled}
-        {...baseInputProps}
         data-testid="email-input"
+        data-cy={dataCy}
+        {...baseInputProps}
       />
     </LabelPasswordInputContainer>
   ),

--- a/src/components/Inputs/GenericInput.tsx
+++ b/src/components/Inputs/GenericInput.tsx
@@ -34,6 +34,7 @@ export interface GenericInputProps
   readonly onChange?: React.ChangeEventHandler<HTMLInputElement>;
   readonly ref?: React.ForwardedRef<HTMLInputElement>;
   readonly id?: string;
+  readonly dataCy?: string;
 }
 
 export const GenericInput: React.FC<GenericInputProps> = forwardRef(
@@ -63,6 +64,7 @@ export const GenericInput: React.FC<GenericInputProps> = forwardRef(
       onChange,
       required,
       disabled,
+      dataCy,
       ...baseInputProps
     },
     ref,
@@ -103,8 +105,9 @@ export const GenericInput: React.FC<GenericInputProps> = forwardRef(
             onChange={onChange}
             required={required}
             disabled={disabled}
-            {...baseInputProps}
             data-testid="generic-input"
+            data-cy={dataCy}
+            {...baseInputProps}
           />
           {passwordToggle && (
             <ViewPasswordButton

--- a/src/components/Inputs/NumberInput.tsx
+++ b/src/components/Inputs/NumberInput.tsx
@@ -28,6 +28,7 @@ export interface NumberInputProps
   readonly required?: boolean;
   readonly ref?: React.ForwardedRef<HTMLInputElement>;
   readonly id?: string;
+  readonly dataCy?: string;
 }
 
 export const NumberInput: React.FC<NumberInputProps> = forwardRef(
@@ -52,6 +53,7 @@ export const NumberInput: React.FC<NumberInputProps> = forwardRef(
       maxNumberValue = 20,
       required,
       disabled,
+      dataCy,
       ...baseInputProps
     },
     ref,
@@ -106,6 +108,7 @@ export const NumberInput: React.FC<NumberInputProps> = forwardRef(
             required={required}
             disabled={disabled}
             onChange={onChangeHandler}
+            data-cy={dataCy}
             {...baseInputProps}
           />
           <ArrowsContainer>

--- a/src/components/Inputs/PasswordInput.tsx
+++ b/src/components/Inputs/PasswordInput.tsx
@@ -30,6 +30,7 @@ export interface PasswordInputProps
   readonly onChange?: React.ChangeEventHandler<HTMLInputElement>;
   readonly ref?: React.ForwardedRef<HTMLInputElement>;
   readonly id?: string;
+  readonly dataCy?: string;
 }
 
 export const PasswordInput: React.FC<PasswordInputProps> = forwardRef(
@@ -56,6 +57,7 @@ export const PasswordInput: React.FC<PasswordInputProps> = forwardRef(
       onChange,
       required,
       disabled,
+      dataCy,
       ...baseInputProps
     },
     ref,
@@ -95,8 +97,9 @@ export const PasswordInput: React.FC<PasswordInputProps> = forwardRef(
             onChange={onChange}
             required={required}
             disabled={disabled}
-            {...baseInputProps}
             data-testid="password-input"
+            data-cy={dataCy}
+            {...baseInputProps}
           />
           <ViewPasswordButton
             data-testid="view-password-button"

--- a/src/components/Inputs/TextInput.tsx
+++ b/src/components/Inputs/TextInput.tsx
@@ -27,6 +27,7 @@ export interface TextInputProps extends InputHTMLAttributes<HTMLInputElement> {
   readonly onChange?: React.ChangeEventHandler<HTMLInputElement>;
   readonly ref?: React.ForwardedRef<HTMLInputElement>;
   readonly id?: string;
+  readonly dataCy?: string;
 }
 
 export const TextInput: React.FC<TextInputProps> = forwardRef(
@@ -53,6 +54,7 @@ export const TextInput: React.FC<TextInputProps> = forwardRef(
       onChange,
       required,
       disabled,
+      dataCy,
       ...baseInputProps
     },
     ref,
@@ -84,8 +86,9 @@ export const TextInput: React.FC<TextInputProps> = forwardRef(
         onChange={onChange}
         required={required}
         disabled={disabled}
-        {...baseInputProps}
         data-testid="text-input"
+        data-cy={dataCy}
+        {...baseInputProps}
       />
     </LabelPasswordInputContainer>
   ),

--- a/src/components/Loader/Loader.tsx
+++ b/src/components/Loader/Loader.tsx
@@ -3,10 +3,13 @@ import styled from 'src/styled';
 import LoaderSVG from '../../assets/svg/icons/loader-icon.svg';
 
 export interface LoaderProps {
-  size?: 'xs' | 'sm' | 'md' | 'lg';
+  readonly size?: 'xs' | 'sm' | 'md' | 'lg';
+  readonly dataCy?: string;
 }
 
-export const Loader: React.FC<LoaderProps> = ({ size } = { size: 'lg' }) => {
+export const Loader: React.FC<LoaderProps> = (
+  { size, dataCy } = { size: 'lg' },
+) => {
   const getLoaderSize = (size?: LoaderProps['size']) => {
     switch (size) {
       case 'xs':
@@ -27,7 +30,8 @@ export const Loader: React.FC<LoaderProps> = ({ size } = { size: 'lg' }) => {
       <LoaderStatus
         size={getLoaderSize(size)}
         aria-label="Loading..."
-        role="status">
+        role="status"
+        data-cy={dataCy}>
         <LoaderIcon size={getLoaderSize(size)}>
           <LoaderSVG />
         </LoaderIcon>

--- a/src/components/Logos/Logo.tsx
+++ b/src/components/Logos/Logo.tsx
@@ -15,15 +15,17 @@ export interface LogoProps {
   readonly logo: keyof typeof logos;
   readonly title: string;
   readonly width?: number;
+  readonly dataCy?: string;
 }
 
 export const Logo: React.FC<LogoProps> = ({
   logo = 'BlockExplorerGradientLogo',
   title = 'Red and black Casper Labs Logo',
   width = 250,
+  dataCy,
 }) => (
   <LogoContainer>
-    <StyledSvg width={width} role="img">
+    <StyledSvg width={width} role="img" data-cy={dataCy}>
       <title>{title}</title>
       {logos[logo]}
     </StyledSvg>

--- a/src/components/ProgressBar/ProgressBar.tsx
+++ b/src/components/ProgressBar/ProgressBar.tsx
@@ -4,23 +4,28 @@ import React from 'react';
 import { defaultTheme } from '../../theme';
 
 export interface ProgressBarProps {
-  processSteps: string[];
-  currentStep: string;
-  className?: string;
+  readonly processSteps: string[];
+  readonly currentStep: string;
+  readonly className?: string;
+  readonly progressBarDataCy?: string;
+  readonly nodeIndicatorDataCy?: string;
 }
 
 export const ProgressBar: React.FC<ProgressBarProps> = ({
   currentStep,
   processSteps,
   className,
+  progressBarDataCy,
+  nodeIndicatorDataCy,
 }) => {
   return (
-    <ProgressBarWrapper data-testid="progress-bar">
+    <ProgressBarWrapper data-testid="progress-bar" data-cy={progressBarDataCy}>
       {processSteps.map(step => {
         return (
           <div className={className} key={step}>
             <NodeIndicator
               data-testid="node-indicator"
+              data-cy={nodeIndicatorDataCy}
               checked={currentStep === step}
             />
             <NodeLabel>{step}</NodeLabel>

--- a/src/components/RadioButtons/RadioButtonGroup.tsx
+++ b/src/components/RadioButtons/RadioButtonGroup.tsx
@@ -11,6 +11,7 @@ export interface OptionGroupProps {
   readonly verticalPadding?: number;
   readonly orientation?: string;
   readonly onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  readonly dataCy?: string;
 }
 
 export const RadioButtonGroup: React.FC<OptionGroupProps> = ({
@@ -18,6 +19,7 @@ export const RadioButtonGroup: React.FC<OptionGroupProps> = ({
   width,
   orientation,
   onChange,
+  dataCy,
 }) => {
   const renderOptions = () => {
     return options.map(
@@ -66,7 +68,8 @@ export const RadioButtonGroup: React.FC<OptionGroupProps> = ({
     <RadioButtonsContainer
       width={width}
       orientation={orientation}
-      data-testid="radio-buttons-container">
+      data-testid="radio-buttons-container"
+      data-cy={dataCy}>
       {renderOptions()}
     </RadioButtonsContainer>
   );

--- a/src/components/SearchBar/SearchBar.tsx
+++ b/src/components/SearchBar/SearchBar.tsx
@@ -7,12 +7,13 @@ import { DropDownSelector, SelectOptions } from '../Selectors';
 import { SearchIcon, ErrorIcon } from '../Icon';
 
 export interface SearchBarProps {
-  onClick: () => void;
-  filters?: SelectOptions[];
-  currentFilter?: SelectOptions;
-  errorMessage?: any;
-  className?: string;
-  defaultValue?: PropsValue<SelectOptions>;
+  readonly onClick: () => void;
+  readonly filters?: SelectOptions[];
+  readonly currentFilter?: SelectOptions;
+  readonly errorMessage?: any;
+  readonly className?: string;
+  readonly defaultValue?: PropsValue<SelectOptions>;
+  readonly dataCy?: string;
 }
 
 export const SearchBar: React.FC<SearchBarProps> = ({
@@ -22,13 +23,17 @@ export const SearchBar: React.FC<SearchBarProps> = ({
   currentFilter,
   className,
   defaultValue,
+  dataCy,
 }) => {
   const handleSubmit = (event: React.FormEvent) => {
     onClick?.();
     event.preventDefault();
   };
   return (
-    <FormContainer data-testid="search-bar" className={className}>
+    <FormContainer
+      className={className}
+      data-testid="search-bar"
+      data-cy={dataCy}>
       <Form onSubmit={handleSubmit}>
         <SearchLabel htmlFor="default-search">Search</SearchLabel>
         <FormComponentsContainer>

--- a/src/components/Selectors/DropDownSelector.tsx
+++ b/src/components/Selectors/DropDownSelector.tsx
@@ -16,6 +16,7 @@ export interface DropDownSelectorProps {
   readonly onChange?: () => void;
   readonly noOptionsMessage?: (obj: { inputValue: string }) => ReactNode;
   className?: string;
+  readonly dataCy?: string;
 }
 
 export const DropDownSelector: React.FC<DropDownSelectorProps> = ({
@@ -26,6 +27,7 @@ export const DropDownSelector: React.FC<DropDownSelectorProps> = ({
   onChange,
   className,
   noOptionsMessage = () => null,
+  dataCy,
 }) => {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const [currentOption, setCurrentOption] = useState<null | SelectOptions>(
@@ -41,7 +43,8 @@ export const DropDownSelector: React.FC<DropDownSelectorProps> = ({
     <SelectWrapper
       className={className}
       isMenuOpen={isMenuOpen}
-      data-testid="select-wrapper">
+      data-testid="select-wrapper"
+      data-cy={dataCy}>
       <SelectLabel htmlFor="select">Select</SelectLabel>
       <Select
         aria-label="select-button"

--- a/src/components/Tables/KeyValueTable/KeyValueTable.tsx
+++ b/src/components/Tables/KeyValueTable/KeyValueTable.tsx
@@ -2,36 +2,51 @@ import React from 'react';
 import styled from 'src/styled';
 
 export interface KeyValueRow {
-  key: React.Key;
-  detailKey: React.ReactNode;
-  value: React.ReactNode;
+  readonly key: React.Key;
+  readonly detailKey: React.ReactNode;
+  readonly value: React.ReactNode;
+  readonly tableKeyDataCy?: string;
+  readonly tableValueDataCy?: string;
 }
 
 export interface KeyValueTableProps {
-  rows: KeyValueRow[];
-  noDividers?: boolean;
-  className?: string;
+  readonly rows: KeyValueRow[];
+  readonly noDividers?: boolean;
+  readonly className?: string;
+  readonly keyValueTableDataCy?: string;
 }
 
 export const KeyValueTable: React.FC<KeyValueTableProps> = ({
   rows,
   noDividers,
   className,
+  keyValueTableDataCy,
 }) => (
-  <KeyValueTableWrapper data-testid="key-value-table" className={className}>
+  <KeyValueTableWrapper
+    data-testid="key-value-table"
+    data-cy={keyValueTableDataCy}
+    className={className}>
     <tbody>
-      {rows.map(({ detailKey, value, key }) => {
-        return (
-          <tr key={key}>
-            <TableLabel data-testid="table-key" noDividers={noDividers}>
-              {detailKey}
-            </TableLabel>
-            <TableValue data-testid="table-value" noDividers={noDividers}>
-              {value}
-            </TableValue>
-          </tr>
-        );
-      })}
+      {rows.map(
+        ({ detailKey, value, key, tableKeyDataCy, tableValueDataCy }) => {
+          return (
+            <tr key={key}>
+              <TableLabel
+                data-testid="table-key"
+                data-cy={tableKeyDataCy}
+                noDividers={noDividers}>
+                {detailKey}
+              </TableLabel>
+              <TableValue
+                data-testid="table-value"
+                data-cy={tableValueDataCy}
+                noDividers={noDividers}>
+                {value}
+              </TableValue>
+            </tr>
+          );
+        },
+      )}
     </tbody>
   </KeyValueTableWrapper>
 );

--- a/src/components/Toggles/BaseToggle/BaseToggle.tsx
+++ b/src/components/Toggles/BaseToggle/BaseToggle.tsx
@@ -3,13 +3,14 @@ import React from 'react';
 import { defaultTheme } from '../../../theme';
 
 export interface BaseToggleProps {
-  toggleOptions: {
+  readonly toggleOptions: {
     left: string;
     right: string;
   };
-  color?: string;
-  className?: string;
-  onToggle?: () => void;
+  readonly color?: string;
+  readonly className?: string;
+  readonly onToggle?: () => void;
+  readonly baseToggleDataCy?: string;
 }
 
 export const BaseToggle: React.FC<BaseToggleProps> = ({
@@ -17,6 +18,7 @@ export const BaseToggle: React.FC<BaseToggleProps> = ({
   color = 'black',
   className,
   onToggle,
+  baseToggleDataCy,
 }) => {
   const [selectedToggleOption, setSelectedToggleOption] = React.useState(
     toggleOptions.left,
@@ -32,7 +34,10 @@ export const BaseToggle: React.FC<BaseToggleProps> = ({
   };
 
   return (
-    <BaseToggleWrapper data-testid="base-toggle" className={className}>
+    <BaseToggleWrapper
+      data-testid="base-toggle"
+      data-cy={baseToggleDataCy}
+      className={className}>
       <ToggleLabel>{toggleOptions.left}</ToggleLabel>
       <Label>
         <Input

--- a/src/components/Toggles/ButtonToggle/ButtonToggle.tsx
+++ b/src/components/Toggles/ButtonToggle/ButtonToggle.tsx
@@ -3,12 +3,13 @@ import styled from 'src/styled';
 import { defaultTheme } from '../../../theme';
 
 export interface ButtonToggleProps {
-  toggleOptions: string[];
-  buttonColor?: string;
-  selectedColor?: string;
-  buttonBorderColor?: string;
-  className?: string;
-  onToggle?: () => void;
+  readonly toggleOptions: string[];
+  readonly buttonColor?: string;
+  readonly selectedColor?: string;
+  readonly buttonBorderColor?: string;
+  readonly className?: string;
+  readonly onToggle?: () => void;
+  readonly buttonToggleDataCy?: string;
 }
 
 export const ButtonToggle: React.FC<ButtonToggleProps> = ({
@@ -18,6 +19,7 @@ export const ButtonToggle: React.FC<ButtonToggleProps> = ({
   buttonBorderColor,
   className,
   onToggle,
+  buttonToggleDataCy,
 }) => {
   const [selectedToggleOption, setSelectedToggleOption] = useState(
     toggleOptions[0],
@@ -28,7 +30,10 @@ export const ButtonToggle: React.FC<ButtonToggleProps> = ({
     onToggle?.();
   };
   return (
-    <div className={className} data-testid="button-toggle">
+    <div
+      className={className}
+      data-testid="button-toggle"
+      data-cy={buttonToggleDataCy}>
       {toggleOptions.map(toggleOption => (
         <ToggleButton
           key={toggleOption}

--- a/src/components/Typography/Typography.tsx
+++ b/src/components/Typography/Typography.tsx
@@ -4,12 +4,18 @@ import { pxToRem } from '../../utils';
 import { defaultTheme } from '../../theme';
 
 export interface TypographyProps {
-  color?: string;
-  font?: string;
-  fontWeight?: number;
-  fontSize?: number;
-  textAlign?: 'left' | 'right' | 'center' | 'justify' | 'initial' | 'inherit';
-  children: React.ReactNode;
+  readonly color?: string;
+  readonly font?: string;
+  readonly fontWeight?: number;
+  readonly fontSize?: number;
+  readonly textAlign?:
+    | 'left'
+    | 'right'
+    | 'center'
+    | 'justify'
+    | 'initial'
+    | 'inherit';
+  readonly children: React.ReactNode;
 }
 
 export const Typography: React.FC<TypographyProps> = ({

--- a/src/components/utility/CopyToClipboard/CopyToClipboard.tsx
+++ b/src/components/utility/CopyToClipboard/CopyToClipboard.tsx
@@ -101,6 +101,7 @@ const CopiedIcon = styled(CopiedSVG)<{
   background-color: ${({ copiedColor }) =>
     copiedColor ? (copiedColor as string) : colors.secondary.CasperGreen};
   border-radius: 0.125rem;
+  margin-left: ${pxToRem(5)};
 `;
 
 const CopyButton = styled.button`


### PR DESCRIPTION
🔥 Summary
-Adds `data-cy="..."` to UiKit Components for basic tests

😤 Problem / Goals
-The complexity of some components (e.g. Card, Table, RadioButtonGroupContainer, SearchForm, etc.) will likely require more test ids for better testing, but this might be better handled at the time of importing the components and writing tests.