### PR TITLE
refactor: breakpoints out of typography

### DIFF
--- a/src/theme/breakpoints.ts
+++ b/src/theme/breakpoints.ts
@@ -1,0 +1,11 @@
+export const breakpoints = {
+  xxs: '420px',
+  xs: '480px',
+  sm: '640px',
+  md: '768px',
+  xmd: '992px',
+  lg: '1024px',
+  xl: '1200px',
+  xxl: '1440px',
+  xxxl: '1600px',
+};

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -1,14 +1,17 @@
 import { colors } from './colors';
 import { typography } from './typography';
+import { breakpoints } from './breakpoints';
 
 export interface ThemeSchema {
   colors: { [key: string]: any };
   typography: { [key: string]: any };
+  breakpoints: { [key: string]: any };
 }
 
 export const defaultTheme = {
   colors,
   typography,
+  breakpoints,
 };
 
 export type TestTheme = typeof defaultTheme;

--- a/src/theme/typography.ts
+++ b/src/theme/typography.ts
@@ -28,18 +28,6 @@ export const typography = {
     bold: 700,
     extrabold: 800,
   },
-  breakpoints: {
-    xxs: '420px',
-    xs: '480px',
-    sm: '640px',
-    md: '768px',
-    xmd: '992px',
-    lg: '1024px',
-    xl: '1200px',
-    xxl: '1440px',
-    xxxl: '1600px',
-  },
-
   lineHeights: {},
   letterSpacing: {},
 };


### PR DESCRIPTION
### 🔥 Summary
- separate breakpoints from typography

### 😤 Problem / Goals
- this makes the use of breakpoints cleaner in projects


