### PR TITLE
Fix: Better NPM Audit Ignores

### DIFF
--- a/.nsprc
+++ b/.nsprc
@@ -7,6 +7,6 @@
   "1092330": {
     "active": true,
     "notes": "Ignored until either word-wrap publishes a new release or whichever package uses word-wrap finds a work around",
-    "expiry": "1 August 2023 9:00am"
+    "expiry": "1 August 2023 9:00 am"
   }
 }

--- a/.nsprc
+++ b/.nsprc
@@ -2,7 +2,7 @@
   "1092310": {
     "active": true,
     "notes": "Ignored until @babel/core fixes semver minimum version to 7.5.2. See https://github.com/babel/babel/blob/04f063ef008fba36a37f91d31d929476ac5e0937/packages/babel-core/package.json#L63",
-    "expiry": "1 July 2023 9:00 am"
+    "expiry": "1 August 2023 9:00 am"
   },
   "1092330": {
     "active": true,


### PR DESCRIPTION
### 🔥 Summary
One of the ignore's had an incorrect date format for the expiry.  This PR fixes that and also bumps the semver expiry to August 1st.  I've looked into upgrading but the latest version of `@babel/core` has not addressed this yet.
