### PR TITLE
Feat-139: Add Tests for Table Component

### DIFF
--- a/.nsprc
+++ b/.nsprc
@@ -4,9 +4,19 @@
     "notes": "Ignored until @babel/core fixes semver minimum version to 7.5.2. See https://github.com/babel/babel/blob/04f063ef008fba36a37f91d31d929476ac5e0937/packages/babel-core/package.json#L63",
     "expiry": "1 August 2023 9:00 am"
   },
+  "1092413": {
+    "active": true,
+    "notes": "Another semver id: Ignored until @babel/core fixes semver minimum version to 7.5.2. See https://github.com/babel/babel/blob/04f063ef008fba36a37f91d31d929476ac5e0937/packages/babel-core/package.json#L63",
+    "expiry": "1 August 2023 9:00 am"
+  },
   "1092330": {
     "active": true,
     "notes": "Ignored until either word-wrap publishes a new release or whichever package uses word-wrap finds a work around",
+    "expiry": "1 August 2023 9:00 am"
+  },
+  "1092448": {
+    "active": true,
+    "notes": "Ignored until jest-environment-jsdom upgrades jsdom and jsdom upgrades tough-cookie",
     "expiry": "1 August 2023 9:00 am"
   }
 }

--- a/src/components/Tables/Table/Table.tsx
+++ b/src/components/Tables/Table/Table.tsx
@@ -35,24 +35,24 @@ interface TableThemeProps {
 }
 
 export interface TableProps<T> {
+  readonly className?: string;
   readonly header?: React.ReactNode;
   readonly columns: ColumnDef<T>[];
   readonly data: T[];
   readonly footer?: React.ReactNode;
-  onSortingChange?: OnChangeFn<SortingState>;
-  sorting?: SortingState;
-  initialSorting?: SortingState;
-  tableBodyLoading?: boolean;
-  currentPageSize?: number;
+  readonly onSortingChange?: OnChangeFn<SortingState>;
+  readonly sorting?: SortingState;
+  readonly initialSorting?: SortingState;
+  readonly tableBodyLoading?: boolean;
+  readonly currentPageSize?: number;
   /*
   - used for deeply nested accessor values to allow for skeleton loaders to work
   - parsing tableData will throw error without
   - placeholderData can be anything, it just has to match nested data type
   */
-  placeholderData?: { [key: string]: any };
-  isLastPage: boolean;
-  theme?: TableThemeProps;
-  readonly className?: string;
+  readonly placeholderData?: { [key: string]: any };
+  readonly isLastPage?: boolean;
+  readonly theme?: TableThemeProps;
 }
 
 export function Table<T extends unknown>({

--- a/src/components/Tables/Table/Table.tsx
+++ b/src/components/Tables/Table/Table.tsx
@@ -105,7 +105,7 @@ export function Table<T extends unknown>({
     return tableBodyLoading
       ? columns.map(column => ({
           ...column,
-          cell: () => <Skeleton />,
+          cell: () => <Skeleton containerTestId="skeleton-loader" />,
         }))
       : columns;
   }, [tableBodyLoading, columns]);
@@ -130,7 +130,8 @@ export function Table<T extends unknown>({
       borderColor={fullTheme.borderColor}
       borderWidth={fullTheme.borderWidth}
       boxShadow={fullTheme.boxShadow}
-      textColor={fullTheme.color}>
+      textColor={fullTheme.color}
+      data-testid="base-table">
       <Header>{header}</Header>
       <StyledTable bgColor={fullTheme.bgColor}>
         <TableHead bgColor={fullTheme.tableHeadBgColor}>

--- a/src/components/Tables/Table/Table.tsx
+++ b/src/components/Tables/Table/Table.tsx
@@ -10,9 +10,9 @@ import {
   useReactTable,
 } from '@tanstack/react-table';
 import Skeleton from 'react-loading-skeleton';
-import styled from '@emotion/styled';
-import { pxToRem } from 'src/utils';
 import { css } from '@emotion/react';
+import { pxToRem } from 'src/utils';
+import styled from '../../../styled';
 import DownArrowLight from '../../../assets/svg/icons/down-icon-light.svg';
 import DownArrowDark from '../../../assets/svg/icons/down-icon-dark.svg';
 

--- a/src/components/Tables/Table/index.ts
+++ b/src/components/Tables/Table/index.ts
@@ -1,1 +1,2 @@
 export * from './Table';
+export * from './partials';

--- a/src/components/Tables/Table/partials/Table.styled.ts
+++ b/src/components/Tables/Table/partials/Table.styled.ts
@@ -1,4 +1,6 @@
 import styled from '@emotion/styled';
+import { defaultTheme } from 'src/theme';
+import { pxToRem } from 'src/utils';
 
 export const TableHead = styled.div<{ color: string }>`
   display: flex;
@@ -18,4 +20,15 @@ export const TotalRows = styled.p`
   white-space: nowrap;
 `;
 
-export const TableFooter = styled.div``;
+export const TableFooter = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  padding: ${pxToRem(20)} 1.5rem;
+  min-width: ${pxToRem(450)};
+
+  @media (min-width: ${defaultTheme.breakpoints.lg}) {
+    justify-content: flex-end;
+    padding: ${pxToRem(20)} 2rem;
+  }
+`;

--- a/src/components/Tables/Table/partials/Table.styled.ts
+++ b/src/components/Tables/Table/partials/Table.styled.ts
@@ -1,0 +1,21 @@
+import styled from '@emotion/styled';
+
+export const TableHead = styled.div<{ color: string }>`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  color: ${({ color }) => color};
+`;
+
+export const TableTitleWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+`;
+
+export const TotalRows = styled.p`
+  margin-right: 1.5rem;
+  white-space: nowrap;
+`;
+
+export const TableFooter = styled.div``;

--- a/src/components/Tables/Table/partials/index.ts
+++ b/src/components/Tables/Table/partials/index.ts
@@ -1,0 +1,1 @@
+export * from './Table.styled';

--- a/src/mocks/index.ts
+++ b/src/mocks/index.ts
@@ -1,0 +1,1 @@
+export * from './mock-block';

--- a/src/mocks/mock-block.ts
+++ b/src/mocks/mock-block.ts
@@ -51,7 +51,7 @@ export const mockBlock: Block = {
   proofs: [],
 };
 
-export const createMockBlocks = (numberOfBlocks: number = 10) => {
+export const createMockBlocks = (numberOfBlocks = 10) => {
   const blocks = new Array(numberOfBlocks).fill(mockBlock) as Block[];
 
   return blocks.map((block, index) => {

--- a/src/mocks/mock-block.ts
+++ b/src/mocks/mock-block.ts
@@ -1,0 +1,60 @@
+export interface BlockHeader {
+  parent_hash: string;
+  state_root_hash: string;
+  body_hash: string;
+  random_bit: boolean;
+  accumulated_seed: string;
+  era_end: null;
+  timestamp: string;
+  era_id: number;
+  height: number;
+  protocol_version: string;
+}
+
+export interface BlockBody {
+  proposer: string;
+  deploy_hashes: string[];
+  transfer_hashes: string[];
+}
+
+export interface Block {
+  hash: string;
+  header: BlockHeader;
+  body: BlockBody;
+  proofs: any[];
+}
+
+export const mockBlock: Block = {
+  hash: '2f95f1fe0c8d64daee3a7c4aa02e12ac0e2a2d0baf02da602e4e119ccb7fde3e',
+  header: {
+    parent_hash:
+      'aba8922d86b9480c9a755fc3de64ebb0d12f8e46a984685a3fac77f19e388c9a',
+    state_root_hash:
+      'c7be5d85569a493b474af56d94ffc925db1fd4c48c4425bda06140559fbf072a',
+    body_hash:
+      '006c899ffb251faecb1e567fba5f9a9c20c383e1c843abcf4576506d293d9fff',
+    random_bit: true,
+    accumulated_seed:
+      '1747ddcfaec39433ca73fef0e9ac9832f50c34f9739d5c12d68f172f022bf4a2',
+    era_end: null,
+    timestamp: '2023-01-16T15:19:38.240Z',
+    era_id: 384,
+    height: 4224,
+    protocol_version: '1.0.0',
+  },
+  body: {
+    proposer:
+      '01c867ff3cf1d4e4e68fc00922fdcb740304def196e223091dee62012f444b9eba',
+    deploy_hashes: [],
+    transfer_hashes: [],
+  },
+  proofs: [],
+};
+
+export const createMockBlocks = (numberOfBlocks: number = 10) => {
+  const blocks = new Array(numberOfBlocks).fill(mockBlock) as Block[];
+
+  return blocks.map((block, index) => {
+    return { ...block, hash: `${block.hash}-${index}` };
+  });
+};

--- a/src/stories/Tables/Table.test.tsx
+++ b/src/stories/Tables/Table.test.tsx
@@ -1,0 +1,146 @@
+import React from 'react';
+import { screen, render } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+import { ColumnDef } from '@tanstack/react-table';
+import { standardizeNumber } from 'src/utils/';
+import { Block, createMockBlocks } from 'src/mocks';
+import { Table } from '../../components/Tables/Table';
+
+const headerContent = 'This is the head content';
+
+const header = <div data-testid="head-content">{headerContent}</div>;
+
+const footerContent = 'This is the footer content';
+
+const footer = <div data-testid="footer-content">{footerContent}</div>;
+
+const data = createMockBlocks(5);
+
+const firstColHeader = 'Block Height';
+const secondColHeader = 'Era';
+const thirdColHeader = 'Deploy';
+const fourthColHeader = 'Age';
+const fifthColHeader = 'Block Hash';
+const sixthColHeader = 'Validator';
+
+const columns: ColumnDef<Block>[] = [
+  {
+    id: 'height',
+    header: firstColHeader,
+    accessorKey: 'header.height',
+    enableSorting: true,
+    cell: ({ getValue }) => <>{standardizeNumber(getValue<number>())}</>,
+  },
+  {
+    header: secondColHeader,
+    accessorKey: 'header.era_id',
+    enableSorting: false,
+    cell: ({ getValue }) => getValue<number>(),
+  },
+  {
+    header: thirdColHeader,
+    accessorKey: 'body',
+    cell: ({ getValue }) => {
+      const body = getValue<Block['body']>();
+
+      return (
+        (body.deploy_hashes?.length ?? 0) + (body.transfer_hashes?.length ?? 0)
+      );
+    },
+    maxSize: 100,
+    enableSorting: false,
+  },
+  {
+    header: fourthColHeader,
+    accessorKey: 'header.timestamp',
+    enableSorting: false,
+    cell: ({ getValue }) => getValue<string>(),
+  },
+  {
+    header: fifthColHeader,
+    accessorKey: 'hash',
+    enableSorting: false,
+    cell: ({ getValue }) => getValue<string>(),
+    minSize: 230,
+  },
+  {
+    header: sixthColHeader,
+    accessorKey: 'body.proposer',
+    enableSorting: false,
+    cell: ({ getValue }) => getValue<string>(),
+    maxSize: 100,
+  },
+];
+
+const Template: React.FC<{ loading?: boolean }> = ({ loading }) => {
+  return (
+    <Table<Block>
+      header={header}
+      columns={columns}
+      data={data}
+      footer={footer}
+      tableBodyLoading={!!loading}
+      isLastPage
+    />
+  );
+};
+
+describe('Table', () => {
+  it('should render out all table columns heads', () => {
+    render(<Template />);
+
+    const firstTableHead = screen.getByText(firstColHeader);
+    const secondTableHead = screen.getByText(secondColHeader);
+    const thirdTableHead = screen.getByText(thirdColHeader);
+    const fourthTableHead = screen.getByText(fourthColHeader);
+    const fifthTableHead = screen.getByText(fifthColHeader);
+    const sixthTableHead = screen.getByText(sixthColHeader);
+
+    expect(firstTableHead).toBeInTheDocument();
+    expect(secondTableHead).toBeInTheDocument();
+    expect(thirdTableHead).toBeInTheDocument();
+    expect(fourthTableHead).toBeInTheDocument();
+    expect(fifthTableHead).toBeInTheDocument();
+    expect(sixthTableHead).toBeInTheDocument();
+  });
+
+  it('should render 5 rows when given 5 data objects', () => {
+    render(<Template />);
+
+    const fifthRow = screen.getByText(data[4].hash);
+
+    expect(fifthRow).toBeInTheDocument();
+  });
+
+  it('should render row column content', () => {
+    render(<Template />);
+
+    const thirdRowSecondColumnContent = screen.getByText(data[2].hash);
+
+    expect(thirdRowSecondColumnContent).toBeInTheDocument();
+  });
+
+  it('should render head content', () => {
+    render(<Template />);
+
+    const headerByTestId = screen.getByTestId('head-content');
+
+    expect(headerByTestId).toHaveTextContent(headerContent);
+  });
+
+  it('should render foot content when given foot content', () => {
+    render(<Template />);
+
+    const footerByTestId = screen.getByTestId('footer-content');
+
+    expect(footerByTestId).toHaveTextContent(footerContent);
+  });
+
+  it('should render loading skeleton when table body is loading', () => {
+    render(<Template loading />);
+
+    const skeletonLoader = screen.getAllByTestId('skeleton-loader');
+
+    expect(skeletonLoader).toHaveLength(data.length * columns.length);
+  });
+});

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,2 +1,3 @@
 export { pxToRem } from './px-to-rem';
+export { standardizeNumber } from './standardize-number';
 export { subComponentHelper } from './sub-component-helper';

--- a/src/utils/standardize-number.ts
+++ b/src/utils/standardize-number.ts
@@ -1,0 +1,3 @@
+export const standardizeNumber = (num: number | string) => {
+  return Number(num).toLocaleString();
+};


### PR DESCRIPTION
Closes #139 

### 🔥 Summary
This PR adds tests for the base table component.

### 😤 Problem / Goals
- There are currently no tests for the base table component
- We are repeating the same styled components for every table in BE

### 🤓 Solution
- Adds basic tests to base table component
- Adds and exports styled components that are being repeated throughout the BE frontend

### 🗒️ Additional Notes
- No Pagination has been tested in this PR as that component has not been migrated over to the UI Kit yet.  I will be recommending our new PM to create a ticket for that.
